### PR TITLE
fix: convert output times to requested timezone

### DIFF
--- a/src/__tests__/time.test.ts
+++ b/src/__tests__/time.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "bun:test";
+import { convertToTimezone, formatTimeForDisplay } from "../time";
+
+describe("time module", () => {
+  describe("convertToTimezone", () => {
+    it("converts UTC time to America/New_York (EST)", () => {
+      // Feb 12 is EST (UTC-5)
+      const result = convertToTimezone("2026-02-12T10:00:00", "UTC", "America/New_York");
+      expect(result).toBe("2026-02-12T05:00:00-05:00");
+    });
+
+    it("converts between non-UTC timezones", () => {
+      // 09:00 in New York (EST) = 15:00 in Berlin (CET, UTC+1)
+      const result = convertToTimezone("2026-02-12T09:00:00", "America/New_York", "Europe/Berlin");
+      expect(result).toBe("2026-02-12T15:00:00+01:00");
+    });
+
+    it("handles same source and target timezone", () => {
+      const result = convertToTimezone("2026-02-12T09:00:00", "America/New_York", "America/New_York");
+      expect(result).toBe("2026-02-12T09:00:00-05:00");
+    });
+
+    it("handles DST transition (summer time)", () => {
+      // July 12 is EDT (UTC-4), not EST (UTC-5)
+      const result = convertToTimezone("2026-07-12T10:00:00", "UTC", "America/New_York");
+      expect(result).toBe("2026-07-12T06:00:00-04:00");
+    });
+
+    it("handles date rollover (UTC time early morning → previous day in west)", () => {
+      // 02:00 UTC on Feb 12 = 21:00 on Feb 11 in New York (EST, UTC-5)
+      const result = convertToTimezone("2026-02-12T02:00:00", "UTC", "America/New_York");
+      expect(result).toBe("2026-02-11T21:00:00-05:00");
+    });
+
+    it("handles date rollover forward (late night in west → next day in east)", () => {
+      // 23:00 in New York on Feb 11 = 05:00 on Feb 12 in Berlin (CET, UTC+1)
+      const result = convertToTimezone("2026-02-11T23:00:00", "America/New_York", "Europe/Berlin");
+      expect(result).toBe("2026-02-12T05:00:00+01:00");
+    });
+
+    it("handles positive UTC offsets", () => {
+      // 10:00 UTC = 19:00 in Tokyo (JST, UTC+9)
+      const result = convertToTimezone("2026-02-12T10:00:00", "UTC", "Asia/Tokyo");
+      expect(result).toBe("2026-02-12T19:00:00+09:00");
+    });
+
+    it("handles half-hour offsets", () => {
+      // 10:00 UTC = 15:30 in Kolkata (IST, UTC+5:30)
+      const result = convertToTimezone("2026-02-12T10:00:00", "UTC", "Asia/Kolkata");
+      expect(result).toBe("2026-02-12T15:30:00+05:30");
+    });
+
+    it("returns original string unchanged when targetTz is undefined", () => {
+      const result = convertToTimezone("2026-02-12T10:00:00", "UTC", undefined as unknown as string);
+      expect(result).toBe("2026-02-12T10:00:00");
+    });
+  });
+
+  describe("formatTimeForDisplay", () => {
+    it("returns HH:mm in target timezone", () => {
+      const result = formatTimeForDisplay("2026-02-12T10:00:00", "UTC", "America/New_York");
+      expect(result).toBe("05:00");
+    });
+
+    it("handles DST (summer)", () => {
+      const result = formatTimeForDisplay("2026-07-12T10:00:00", "UTC", "America/New_York");
+      expect(result).toBe("06:00");
+    });
+
+    it("returns original HH:mm when targetTz is undefined", () => {
+      const result = formatTimeForDisplay("2026-02-12T10:30:00", "UTC", undefined as unknown as string);
+      expect(result).toBe("10:30");
+    });
+  });
+});

--- a/src/calendars.ts
+++ b/src/calendars.ts
@@ -12,6 +12,7 @@ import type {
   EventListResponse,
   CreateEventInput,
 } from "./types";
+import { convertToTimezone } from "./time";
 
 // ---------------------------------------------------------------------------
 // Calendar cache (avoids repeated /calendars/list calls within one session)
@@ -180,6 +181,7 @@ export async function findFreeSlots(options: {
   end: string;
   calendarIds?: string[];
   minMinutes?: number;
+  timeZone?: string;
 }): Promise<FreeSlot[]> {
   const events = await listEvents({
     start: options.start,
@@ -218,9 +220,15 @@ export async function findFreeSlots(options: {
   const rangeEnd = new Date(options.end).getTime();
   const minMs = (options.minMinutes ?? 30) * 60 * 1000;
 
-  // Format as floating local time (no Z suffix) to match event start format
-  const toFloatingLocal = (ms: number): string =>
-    new Date(ms).toISOString().replace(/\.000Z$/, "").replace(/Z$/, "");
+  // Format timestamps: if timezone requested, convert; otherwise floating UTC
+  const formatTime = (ms: number): string => {
+    if (options.timeZone) {
+      // Convert UTC ms to target timezone with offset
+      const utcIso = new Date(ms).toISOString().replace(/\.000Z$/, "").replace(/Z$/, "");
+      return convertToTimezone(utcIso, "UTC", options.timeZone);
+    }
+    return new Date(ms).toISOString().replace(/\.000Z$/, "").replace(/Z$/, "");
+  };
 
   const freeSlots: FreeSlot[] = [];
   let cursor = rangeStart;
@@ -230,8 +238,8 @@ export async function findFreeSlots(options: {
       const gap = busyStart - cursor;
       if (gap >= minMs) {
         freeSlots.push({
-          start: toFloatingLocal(cursor),
-          end: toFloatingLocal(busyStart),
+          start: formatTime(cursor),
+          end: formatTime(busyStart),
           duration: formatDuration(gap),
         });
       }
@@ -244,8 +252,8 @@ export async function findFreeSlots(options: {
     const gap = rangeEnd - cursor;
     if (gap >= minMs) {
       freeSlots.push({
-        start: toFloatingLocal(cursor),
-        end: toFloatingLocal(rangeEnd),
+        start: formatTime(cursor),
+        end: formatTime(rangeEnd),
         duration: formatDuration(gap),
       });
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ import { sendChat } from "./chat";
 import { MorgenApiError } from "./morgen-api";
 import { authenticate } from "./morgen-cdp";
 import type { MorgenTask, MorgenEvent, MorgenCalendar, CreateTaskInput, UpdateTaskInput } from "./types";
+import { convertToTimezone, formatTimeForDisplay } from "./time";
 import pkg from "../package.json";
 
 const VERSION = pkg.version;
@@ -202,16 +203,22 @@ function providerBadge(integrationId: string): string {
   return `${colors.dim}[${integrationId}]${colors.reset}`;
 }
 
-function formatTask(task: MorgenTask): string {
+function formatTask(task: MorgenTask, targetTz?: string): string {
   const progress =
     task.progress === "completed"
       ? `${colors.green}\u2713${colors.reset}`
       : task.progress === "in-process"
         ? `${colors.yellow}\u25D0${colors.reset}`
         : `${colors.dim}\u25CB${colors.reset}`;
-  const due = task.due
-    ? `  ${colors.dim}due ${task.due.split("T")[0]}${colors.reset}`
-    : "";
+  let due = "";
+  if (task.due) {
+    if (targetTz && task.timeZone) {
+      const converted = convertToTimezone(task.due, task.timeZone, targetTz);
+      due = `  ${colors.dim}due ${converted.split("T")[0]}${colors.reset}`;
+    } else {
+      due = `  ${colors.dim}due ${task.due.split("T")[0]}${colors.reset}`;
+    }
+  }
   const pri =
     task.priority && task.priority > 0 && task.priority <= 3
       ? ` ${colors.red}!${colors.reset}`
@@ -222,10 +229,10 @@ function formatTask(task: MorgenTask): string {
   return `${progress} ${task.title}${pri}${due}${source}  ${colors.dim}${task.id}${colors.reset}`;
 }
 
-function formatTaskList(tasks: MorgenTask[]): string {
+function formatTaskList(tasks: MorgenTask[], targetTz?: string): string {
   if (tasks.length === 0)
     return `${colors.dim}No tasks found${colors.reset}`;
-  return tasks.map(formatTask).join("\n");
+  return tasks.map((t) => formatTask(t, targetTz)).join("\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -392,9 +399,14 @@ async function handleTasks(opts: CliOptions) {
       tasks = await listTasks({ limit: opts.limit, accountId: opts.account });
     }
     if (opts.json) {
-      console.log(JSON.stringify(tasks, null, 2));
+      const output = opts.timeZone
+        ? tasks.map((t) => t.due && t.timeZone
+            ? { ...t, due: convertToTimezone(t.due, t.timeZone, opts.timeZone!) }
+            : t)
+        : tasks;
+      console.log(JSON.stringify(output, null, 2));
     } else {
-      console.log(formatTaskList(tasks));
+      console.log(formatTaskList(tasks, opts.timeZone));
     }
     return;
   }
@@ -406,9 +418,12 @@ async function handleTasks(opts: CliOptions) {
     }
     const task = await getTask(opts.positional);
     if (opts.json) {
-      console.log(JSON.stringify(task, null, 2));
+      const output = opts.timeZone && task.due && task.timeZone
+        ? { ...task, due: convertToTimezone(task.due, task.timeZone, opts.timeZone) }
+        : task;
+      console.log(JSON.stringify(output, null, 2));
     } else {
-      console.log(formatTask(task));
+      console.log(formatTask(task, opts.timeZone));
       if (task.description) console.log(`\n${task.description}`);
     }
     return;
@@ -611,10 +626,15 @@ function formatCalendar(cal: MorgenCalendar): string {
   return `  ${write} ${cal.name}  ${colors.dim}${cal.id}${colors.reset}`;
 }
 
-function formatEvent(event: MorgenEvent & { calendarName?: string }): string {
-  const time = event.showWithoutTime
-    ? `${colors.cyan}all-day${colors.reset}`
-    : `${colors.cyan}${event.start.split("T")[1]?.slice(0, 5) || event.start}${colors.reset}`;
+function formatEvent(event: MorgenEvent & { calendarName?: string }, targetTz?: string): string {
+  let timeStr: string;
+  if (event.showWithoutTime) {
+    timeStr = `${colors.cyan}all-day${colors.reset}`;
+  } else if (targetTz) {
+    timeStr = `${colors.cyan}${formatTimeForDisplay(event.start, event.timeZone, targetTz)}${colors.reset}`;
+  } else {
+    timeStr = `${colors.cyan}${event.start.split("T")[1]?.slice(0, 5) || event.start}${colors.reset}`;
+  }
   const dur = event.duration ? `  ${colors.dim}${event.duration}${colors.reset}` : "";
   const cal = event.calendarName
     ? `  ${colors.dim}[${event.calendarName}]${colors.reset}`
@@ -622,7 +642,7 @@ function formatEvent(event: MorgenEvent & { calendarName?: string }): string {
   const status = event.freeBusyStatus && event.freeBusyStatus !== "busy"
     ? `  ${colors.yellow}(${event.freeBusyStatus})${colors.reset}`
     : "";
-  return `${time} ${event.title}${dur}${status}${cal}  ${colors.dim}${event.id}${colors.reset}`;
+  return `${timeStr} ${event.title}${dur}${status}${cal}  ${colors.dim}${event.id}${colors.reset}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -669,13 +689,19 @@ async function handleCalendar(opts: CliOptions) {
     });
 
     if (opts.json) {
-      console.log(JSON.stringify(events, null, 2));
+      const output = opts.timeZone
+        ? events.map((e) => ({
+            ...e,
+            start: e.showWithoutTime ? e.start : convertToTimezone(e.start, e.timeZone, opts.timeZone!),
+          }))
+        : events;
+      console.log(JSON.stringify(output, null, 2));
     } else {
       if (events.length === 0) {
         console.log(`${colors.dim}No events found${colors.reset}`);
       } else {
         for (const event of events) {
-          console.log(formatEvent(event));
+          console.log(formatEvent(event, opts.timeZone));
         }
       }
     }
@@ -800,6 +826,7 @@ async function handleCalendar(opts: CliOptions) {
       end: opts.end,
       calendarIds: opts.calendars,
       minMinutes: opts.minMinutes,
+      timeZone: opts.timeZone,
     });
 
     if (opts.json) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export {
   resetCalendarCache,
 } from "./calendars.ts";
 export { sendChat, parseSSEStream } from "./chat.ts";
+export { convertToTimezone, formatTimeForDisplay } from "./time.ts";
 export { TOOL_DEFINITIONS, executeTool } from "./tools.ts";
 export type { ListTasksOptions } from "./tasks.ts";
 export {

--- a/src/time.ts
+++ b/src/time.ts
@@ -1,0 +1,155 @@
+/**
+ * Timezone conversion utilities
+ *
+ * Pure functions for converting floating local times between timezones.
+ * Uses built-in Intl APIs — zero dependencies.
+ */
+
+/**
+ * Convert a floating local time from one timezone to another,
+ * returning ISO 8601 with UTC offset (e.g., "2026-02-12T05:00:00-05:00").
+ *
+ * If targetTz is falsy, returns the original string unchanged.
+ */
+export function convertToTimezone(
+  floatingLocal: string,
+  sourceTz: string,
+  targetTz: string,
+): string {
+  if (!targetTz) return floatingLocal;
+
+  // Interpret the floating local time in the source timezone
+  // by constructing a Date that represents that wall-clock time in sourceTz
+  const utcMs = floatingLocalToUtcMs(floatingLocal, sourceTz);
+
+  // Format in the target timezone
+  const date = new Date(utcMs);
+  const parts = getDateParts(date, targetTz);
+  const offset = getUtcOffset(date, targetTz);
+
+  return (
+    `${parts.year}-${parts.month}-${parts.day}` +
+    `T${parts.hour}:${parts.minute}:${parts.second}` +
+    `${formatOffset(offset)}`
+  );
+}
+
+/**
+ * Format a floating local time as HH:mm in the target timezone.
+ * If targetTz is falsy, extracts HH:mm from the original string.
+ */
+export function formatTimeForDisplay(
+  floatingLocal: string,
+  sourceTz: string,
+  targetTz: string,
+): string {
+  if (!targetTz) {
+    return floatingLocal.split("T")[1]?.slice(0, 5) || floatingLocal;
+  }
+
+  const utcMs = floatingLocalToUtcMs(floatingLocal, sourceTz);
+  const parts = getDateParts(new Date(utcMs), targetTz);
+  return `${parts.hour}:${parts.minute}`;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a floating local time string to UTC milliseconds,
+ * interpreting it as wall-clock time in the given timezone.
+ */
+function floatingLocalToUtcMs(floatingLocal: string, tz: string): number {
+  // Parse components from the string
+  const [datePart, timePart] = floatingLocal.split("T");
+  const [year, month, day] = datePart.split("-").map(Number);
+  const [hour, minute, second] = (timePart || "00:00:00").split(":").map(Number);
+
+  // Create a Date in UTC, then adjust for the source timezone offset
+  // First guess: create a UTC date with these components
+  const guessUtc = Date.UTC(year, month - 1, day, hour, minute, second || 0);
+
+  // Get the offset of the source timezone at this UTC instant
+  const offsetMs = getUtcOffset(new Date(guessUtc), tz) * 60000;
+
+  // The actual UTC time is: guessUtc - offsetMs
+  // (if tz is UTC-5, the wall clock is 5h behind UTC, so UTC = wall + 5h)
+  const adjustedUtc = guessUtc - offsetMs;
+
+  // Verify: the offset might differ at the adjusted time (DST edge)
+  const verifyOffset = getUtcOffset(new Date(adjustedUtc), tz) * 60000;
+  if (verifyOffset !== offsetMs) {
+    return guessUtc - verifyOffset;
+  }
+
+  return adjustedUtc;
+}
+
+/**
+ * Get the UTC offset in minutes for a timezone at a given instant.
+ * Positive = east of UTC (e.g., +60 for CET), negative = west (e.g., -300 for EST).
+ */
+function getUtcOffset(date: Date, tz: string): number {
+  // Format in UTC and in the target timezone, then compute difference
+  const utcParts = getDateParts(date, "UTC");
+  const tzParts = getDateParts(date, tz);
+
+  const utcMins =
+    Number(utcParts.year) * 525960 +
+    Number(utcParts.month) * 43800 +
+    Number(utcParts.day) * 1440 +
+    Number(utcParts.hour) * 60 +
+    Number(utcParts.minute);
+
+  const tzMins =
+    Number(tzParts.year) * 525960 +
+    Number(tzParts.month) * 43800 +
+    Number(tzParts.day) * 1440 +
+    Number(tzParts.hour) * 60 +
+    Number(tzParts.minute);
+
+  return tzMins - utcMins;
+}
+
+interface DateParts {
+  year: string;
+  month: string;
+  day: string;
+  hour: string;
+  minute: string;
+  second: string;
+}
+
+function getDateParts(date: Date, tz: string): DateParts {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+
+  const parts = fmt.formatToParts(date);
+  const get = (type: string) => parts.find((p) => p.type === type)?.value || "00";
+
+  return {
+    year: get("year"),
+    month: get("month"),
+    day: get("day"),
+    hour: get("hour") === "24" ? "00" : get("hour"),
+    minute: get("minute"),
+    second: get("second"),
+  };
+}
+
+function formatOffset(offsetMinutes: number): string {
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const abs = Math.abs(offsetMinutes);
+  const hours = Math.floor(abs / 60);
+  const mins = abs % 60;
+  return `${sign}${String(hours).padStart(2, "0")}:${String(mins).padStart(2, "0")}`;
+}


### PR DESCRIPTION
## Summary

- Fixes #7: `--timezone` flag now converts all output times (JSON and human-readable) to the requested timezone
- Adds `src/time.ts` with pure `Intl.DateTimeFormat`-based timezone conversion utilities (zero dependencies)
- Wires conversion into calendar events, free slots, and task output paths
- JSON output uses ISO 8601 with offset (e.g., `2026-02-12T05:00:00-05:00`)

## Test plan

- [x] 12 new unit tests for timezone conversion (EST, EDT/DST, date rollover, half-hour offsets, passthrough)
- [x] All 86 existing tests pass (no regressions)
- [ ] Manual: `morgen calendar events --timezone America/New_York --json` shows times with offset
- [ ] Manual: `morgen calendar free --timezone America/New_York` shows local times
- [ ] Manual: Without `--timezone`, output unchanged (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)