### PR TITLE
fix: don't classify other apps' app.html as Morgen; retry across targets

### DIFF
--- a/src/__tests__/morgen-cdp.test.ts
+++ b/src/__tests__/morgen-cdp.test.ts
@@ -7,6 +7,8 @@ import { mkdtempSync, rmSync } from "fs";
 let mockTargets: any[] = [];
 let mockCDPClient: any = null;
 let mockListShouldThrow = false;
+/** Optional per-target client factory, for exercising retry across targets. */
+let mockClientForTarget: ((target: any) => any) | null = null;
 
 // Redirect session writes to a per-suite temp dir so tests never touch
 // the user's real ~/.config/morgen-cli/session.json.
@@ -16,7 +18,8 @@ process.on("exit", () => { try { rmSync(TEST_TMP_DIR, { recursive: true, force: 
 
 // ── Mock chrome-remote-interface BEFORE importing module under test ──
 mock.module("chrome-remote-interface", () => {
-  const cdpFn = async (_opts: any) => mockCDPClient;
+  const cdpFn = async (opts: any) =>
+    mockClientForTarget ? mockClientForTarget(opts?.target) : mockCDPClient;
   cdpFn.List = async (_opts: any) => {
     if (mockListShouldThrow) throw new Error("ECONNREFUSED");
     return mockTargets;
@@ -188,5 +191,68 @@ describe("getSessionToken", () => {
     mockTargets = [makeElectronTarget()];
     const token = await getSessionToken(9400);
     expect(token).toBe("ai-tok-xyz");
+  });
+});
+
+describe("target resilience", () => {
+  beforeEach(() => {
+    mockTargets = [];
+    mockCDPClient = null;
+    mockClientForTarget = null;
+    mockListShouldThrow = false;
+  });
+
+  afterEach(() => {
+    mockClientForTarget = null;
+    globalThis.fetch = originalFetch;
+    delete process.env.CDP_TIMEOUT_MS;
+  });
+
+  it("a wedged target does not fail the refresh when another can serve it", async () => {
+    // Two Morgen web targets. The first never answers Runtime.evaluate — the
+    // real failure mode, a busy renderer. The second must still serve it.
+    const wedged = { id: "wedged", type: "page", url: "https://web.morgen.so/wedged" };
+    const good = { id: "good", type: "page", url: "https://web.morgen.so/good" };
+    mockTargets = [wedged, good];
+
+    mockClientForTarget = (target: any) => ({
+      Runtime: {
+        evaluate: async (opts: any) => {
+          if (target?.id === "wedged") return new Promise(() => {}); // never settles
+          if (String(opts.expression).includes("morgen-email")) {
+            return { result: { value: "user@example.com" } };
+          }
+          return {
+            result: { value: JSON.stringify({ refreshToken: "rt", deviceId: "did" }) },
+          };
+        },
+      },
+      close: async () => {},
+    });
+
+    process.env.CDP_TIMEOUT_MS = "150"; // keep the wedged attempt short
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ token: "api-tok", aiToken: "ai-tok", expiresIn: 3600 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as typeof fetch;
+
+    const res = await authenticate(9999);
+    expect(res.email).toBe("user@example.com");
+  });
+
+  it("surfaces the last error when every target is wedged", async () => {
+    mockTargets = [
+      { id: "a", type: "page", url: "https://web.morgen.so/a" },
+      { id: "b", type: "page", url: "https://web.morgen.so/b" },
+    ];
+    mockClientForTarget = () => ({
+      Runtime: { evaluate: async () => new Promise(() => {}) },
+      close: async () => {},
+    });
+    process.env.CDP_TIMEOUT_MS = "100";
+
+    // Must reject with the timeout, not hang and not swallow it.
+    await expect(authenticate(9999)).rejects.toThrow(/timed out after 100ms/);
   });
 });

--- a/src/__tests__/morgen-cdp.test.ts
+++ b/src/__tests__/morgen-cdp.test.ts
@@ -235,7 +235,7 @@ describe("target resilience", () => {
       new Response(JSON.stringify({ token: "api-tok", aiToken: "ai-tok", expiresIn: 3600 }), {
         status: 200,
         headers: { "content-type": "application/json" },
-      })) as typeof fetch;
+      })) as unknown as typeof fetch;
 
     const res = await authenticate(9999);
     expect(res.email).toBe("user@example.com");

--- a/src/__tests__/morgen-target.test.ts
+++ b/src/__tests__/morgen-target.test.ts
@@ -56,6 +56,16 @@ describe("classifyTarget", () => {
     expect(classifyTarget(page("file:///opt/Morgen/resources/app.html"))).toBe("electron");
   });
 
+  test("query/fragment cannot make another app look like Morgen", () => {
+    // /morgen/i must scan origin+path only. Scanning the whole URL let a route
+    // or query decide identity — and 1Password's page at #/morgen/settings is
+    // exactly the shape that matters.
+    expect(
+      classifyTarget(page("chrome-extension://abc/app/app.html#/morgen/settings"))
+    ).toBeNull();
+    expect(classifyTarget(page("https://example.com/app.html?next=morgen"))).toBeNull();
+  });
+
   test("another app's app.html is NOT the Morgen desktop app", () => {
     // Real target seen live: 1Password's extension serves an app.html. A bare
     // "app.html" match classified it as Electron, and since Electron ranks

--- a/src/__tests__/morgen-target.test.ts
+++ b/src/__tests__/morgen-target.test.ts
@@ -1,5 +1,49 @@
 import { describe, expect, test } from "bun:test";
-import { classifyTarget, pickTarget, noTargetHint, withTimeout } from "../morgen-cdp";
+import {
+  classifyTarget,
+  pickTarget,
+  rankTargets,
+  noTargetHint,
+  withTimeout,
+} from "../morgen-cdp";
+
+describe("rankTargets", () => {
+  const page = (url: string) => ({ type: "page", url });
+
+  test("returns EVERY viable target, not just the best", () => {
+    // The point: one wedged tab must not fail a refresh another tab could serve.
+    const ranked = rankTargets([
+      page("https://web.morgen.so/a"),
+      page("https://example.com"),
+      page("https://web.morgen.so/b"),
+    ]);
+    expect(ranked).toHaveLength(2);
+    expect(ranked.every((r) => r.source === "chrome")).toBe(true);
+  });
+
+  test("Electron ranks ahead of web, wherever it appears in the list", () => {
+    const ranked = rankTargets([
+      page("https://web.morgen.so/"),
+      page("morgen://./app.html"),
+    ]);
+    expect(ranked.map((r) => r.source)).toEqual(["electron", "chrome"]);
+  });
+
+  test("excludes non-page and unrelated targets", () => {
+    const ranked = rankTargets([
+      { type: "service_worker", url: "https://web.morgen.so/sw.js" },
+      { type: "shared_worker", url: "https://web.morgen.so/w.js" },
+      page("https://example.com"),
+      page("https://web.morgen.so/"),
+    ]);
+    expect(ranked).toHaveLength(1);
+  });
+
+  test("empty when nothing matches", () => {
+    expect(rankTargets([page("https://example.com")])).toEqual([]);
+    expect(rankTargets([])).toEqual([]);
+  });
+});
 
 const page = (url: string) => ({ type: "page", url });
 
@@ -8,8 +52,21 @@ describe("classifyTarget", () => {
     expect(classifyTarget(page("morgen://./app.html"))).toBe("electron");
   });
 
-  test("a bare app.html URL still counts as Electron", () => {
+  test("a bare app.html URL still counts as Electron when it is Morgen's", () => {
     expect(classifyTarget(page("file:///opt/Morgen/resources/app.html"))).toBe("electron");
+  });
+
+  test("another app's app.html is NOT the Morgen desktop app", () => {
+    // Real target seen live: 1Password's extension serves an app.html. A bare
+    // "app.html" match classified it as Electron, and since Electron ranks
+    // first it was picked ahead of the real web.morgen.so tab — failing the
+    // refresh against 1Password's localStorage.
+    expect(
+      classifyTarget(
+        page("chrome-extension://aeblfdkhhhdcdjpifhhbdiojplfjncoa/app/app.html#/page/settings")
+      )
+    ).toBeNull();
+    expect(classifyTarget(page("https://example.com/app.html"))).toBeNull();
   });
 
   test("morgen.so is the web app, on any subdomain", () => {

--- a/src/morgen-cdp.ts
+++ b/src/morgen-cdp.ts
@@ -18,8 +18,25 @@ import { homedir } from "os";
 
 const API_BASE = "https://api.morgen.so";
 const DEFAULT_PORT = parseInt(process.env.CDP_PORT || "9253", 10);
-/** Upper bound on any single CDP round-trip. Override with CDP_TIMEOUT_MS. */
-const CDP_TIMEOUT_MS = parseInt(process.env.CDP_TIMEOUT_MS || "10000", 10);
+const DEFAULT_CDP_TIMEOUT_MS = 10_000;
+
+/**
+ * Upper bound on any single CDP round-trip. Override with CDP_TIMEOUT_MS.
+ *
+ * Resolved at call time, not import time — the same reason getSessionFile() is:
+ * a module-level const captures the env before a test (or a caller) can set it.
+ *
+ * Validated rather than trusted: parseInt("garbage") is NaN and
+ * setTimeout(fn, NaN) fires immediately, so a typo would make every CDP call
+ * "time out" instantly and every refresh fail with a misleading message.
+ */
+function cdpTimeoutMs(): number {
+  const raw = process.env.CDP_TIMEOUT_MS;
+  if (!raw) return DEFAULT_CDP_TIMEOUT_MS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_CDP_TIMEOUT_MS;
+  return n;
+}
 
 /**
  * Resolve session file path at call time so tests can redirect via
@@ -56,7 +73,7 @@ export interface SessionInfo {
  * playing YouTube tab never answered a CDP command while four other tabs
  * answered instantly. Without a bound, that is an indefinite hang and no error.
  */
-export function withTimeout<T>(p: Promise<T>, what: string, ms = CDP_TIMEOUT_MS): Promise<T> {
+export function withTimeout<T>(p: Promise<T>, what: string, ms = cdpTimeoutMs()): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(
       () => reject(new Error(`${what} timed out after ${ms}ms — is the Morgen tab responsive?`)),
@@ -72,24 +89,54 @@ export function withTimeout<T>(p: Promise<T>, what: string, ms = CDP_TIMEOUT_MS)
 /** Classify a CDP target as Morgen Electron, Chrome web app, or neither. */
 export function classifyTarget(t: any): ConnectionSource | null {
   if (t.type !== "page") return null;
-  // The desktop app loads morgen://./app.html; some builds surface the bare
-  // app.html URL instead, so accept either as Electron.
-  if (t.url?.startsWith("morgen://") || t.url?.includes("app.html")) return "electron";
-  if (t.url?.includes("morgen.so")) return "chrome";
+  const url: string | undefined = t.url;
+  if (!url) return null;
+
+  // The desktop app loads morgen://./app.html.
+  if (url.startsWith("morgen://")) return "electron";
+
+  // Some builds surface a bare app.html path instead of the morgen:// scheme.
+  // It must still be Morgen's: a bare `app.html` match is far too broad —
+  // 1Password's extension serves
+  // chrome-extension://<id>/app/app.html#/page/settings, which was being
+  // classified as the Morgen desktop app and, since Electron ranks first,
+  // picked ahead of the real web.morgen.so tab. Reading credentials from
+  // 1Password's localStorage then failed the whole refresh.
+  if (url.includes("app.html") && /morgen/i.test(url)) return "electron";
+
+  if (url.includes("morgen.so")) return "chrome";
   return null;
 }
 
 /**
- * Pick the best Morgen target: Electron first (richer credentials via the
- * electronAPI bridge), else the web app. Shared by the session and Firebase
- * credential paths so both honour the same preference order.
+ * Rank every viable Morgen target, best first: Electron before web (richer
+ * credentials via the electronAPI bridge).
+ *
+ * Every one, not just the best: credentials here live in localStorage and
+ * IndexedDB, so they must be read with Runtime.evaluate against a page target —
+ * there is no browser-level equivalent as there is for cookies. A page routes
+ * through its renderer, and a busy renderer never answers, so committing to a
+ * single target means one wedged tab fails the whole refresh even when another
+ * viable Morgen target is sitting right there. Measured in a sibling tool: 4 of
+ * 8 live page targets were wedged at one point, and which ones drift over time.
+ */
+export function rankTargets<T>(targets: T[]): Array<{ source: ConnectionSource; target: T }> {
+  const ranked: Array<{ source: ConnectionSource; target: T }> = [];
+  for (const source of ["electron", "chrome"] as const) {
+    for (const target of targets) {
+      if (classifyTarget(target) === source) ranked.push({ source, target });
+    }
+  }
+  return ranked;
+}
+
+/**
+ * The single best Morgen target, or null.
+ *
+ * Prefer rankTargets when you can retry — this cannot survive a wedged tab.
  */
 export function pickTarget<T>(targets: T[]): { source: ConnectionSource; target: T } | null {
-  for (const source of ["electron", "chrome"] as const) {
-    const target = targets.find((t) => classifyTarget(t) === source);
-    if (target) return { source, target };
-  }
-  return null;
+  return rankTargets(targets)[0] ?? null;
 }
 
 /** Platform-appropriate command for starting the Morgen desktop app with CDP. */
@@ -129,18 +176,53 @@ export async function isMorgenRunning(port = DEFAULT_PORT): Promise<ConnectionSo
 }
 
 /**
- * Connect to Morgen via CDP. Finds the morgen.so tab in Chrome or the Electron app.
- * Returns the connection source and CDP client.
+ * Run `fn` against the best Morgen target that actually answers.
+ *
+ * Tries each viable target in rank order (Electron, then web), moving on when
+ * one fails or wedges, and always closing the client. Only the CDP work belongs
+ * in `fn` — keep network calls outside, so a backend failure is not retried
+ * against every tab.
+ *
+ * Retrying matters because these credentials can only be read with
+ * Runtime.evaluate against a page target (localStorage/IndexedDB have no
+ * browser-level CDP equivalent, unlike cookies). A page routes through its
+ * renderer and a busy renderer never answers, so committing to one target lets
+ * a single wedged tab fail a refresh that another open Morgen target could have
+ * served. withTimeout bounds each attempt, so a wedge costs a timeout, not the
+ * refresh.
  */
-async function connectToMorgen(port: number): Promise<{ source: ConnectionSource; client: CDP.Client }> {
+async function withMorgenTarget<T>(
+  port: number,
+  fn: (client: CDP.Client, source: ConnectionSource) => Promise<T>
+): Promise<T> {
   const host = getCDPHost();
   const targets = await CDP.List({ host, port });
 
-  const picked = pickTarget(targets);
-  if (!picked) throw new Error(noTargetHint(port));
+  const ranked = rankTargets(targets);
+  if (ranked.length === 0) throw new Error(noTargetHint(port));
 
-  const client = await CDP({ host, port, target: picked.target });
-  return { source: picked.source, client };
+  let lastError: unknown;
+  for (const { source, target } of ranked) {
+    let client: CDP.Client | null = null;
+    try {
+      client = await withTimeout(
+        CDP({ host, port, target }),
+        `connecting to the ${source} target`
+      );
+      return await fn(client, source);
+    } catch (err) {
+      lastError = err;
+    } finally {
+      if (client) {
+        try {
+          await client.close();
+        } catch {
+          // ignore
+        }
+      }
+    }
+  }
+  throw lastError ?? new Error(noTargetHint(port));
 }
 
 /** Extract refresh token and device ID from an existing CDP client. */
@@ -270,16 +352,14 @@ export async function getSessionToken(port = DEFAULT_PORT): Promise<string> {
   if (cached) return cached.token;
 
   // Extract from running Morgen app or Chrome
-  const conn = await connectToMorgen(port);
-  try {
-    const creds = await extractCredentialsFromClient(conn.client);
-    const session = await exchangeForSession(creds.refreshToken, creds.deviceId);
-    session.source = conn.source;
-    await saveSession(session);
-    return session.token;
-  } finally {
-    await conn.client.close();
-  }
+  const { creds, source } = await withMorgenTarget(port, async (client, source) => ({
+    creds: await extractCredentialsFromClient(client),
+    source,
+  }));
+  const session = await exchangeForSession(creds.refreshToken, creds.deviceId);
+  session.source = source;
+  await saveSession(session);
+  return session.token;
 }
 
 /**
@@ -291,23 +371,22 @@ export async function authenticate(port = DEFAULT_PORT): Promise<{
   expiresAt: number;
   source: ConnectionSource;
 }> {
-  const conn = await connectToMorgen(port);
-  try {
-    const creds = await extractCredentialsFromClient(conn.client);
-    const session = await exchangeForSession(creds.refreshToken, creds.deviceId);
-    session.source = conn.source;
-    await saveSession(session);
+  // Both reads come from whichever target answers, so they cannot disagree.
+  const { creds, email, source } = await withMorgenTarget(port, async (client, source) => {
+    const creds = await extractCredentialsFromClient(client);
+    const result = await withTimeout(
+      client.Runtime.evaluate({
+        expression: `localStorage.getItem("morgen-email") || "unknown"`,
+        returnByValue: true,
+      }),
+      "reading Morgen account email"
+    );
+    return { creds, email: result.result.value as string, source };
+  });
 
-    // Get email from the same connection
-    const { Runtime } = conn.client;
-    const result = await withTimeout(Runtime.evaluate({
-      expression: `localStorage.getItem("morgen-email") || "unknown"`,
-      returnByValue: true,
-    }), "reading Morgen account email");
-    const email = result.result.value;
+  const session = await exchangeForSession(creds.refreshToken, creds.deviceId);
+  session.source = source;
+  await saveSession(session);
 
-    return { email, expiresAt: session.expiresAt, source: conn.source };
-  } finally {
-    await conn.client.close();
-  }
+  return { email, expiresAt: session.expiresAt, source };
 }

--- a/src/morgen-cdp.ts
+++ b/src/morgen-cdp.ts
@@ -19,6 +19,18 @@ import { homedir } from "os";
 const API_BASE = "https://api.morgen.so";
 const DEFAULT_PORT = parseInt(process.env.CDP_PORT || "9253", 10);
 const DEFAULT_CDP_TIMEOUT_MS = 10_000;
+/**
+ * How many targets the retry loop may spend its budget on.
+ *
+ * The budget must exceed a single call's timeout or the first wedged target
+ * consumes all of it and retry never happens — CDP_TIMEOUT_MS bounds one CALL,
+ * so the loop gets a multiple of it. Realistically there are one or two Morgen
+ * targets (rankTargets only returns Morgen ones, never every open tab), so this
+ * bounds the pathological case without starving the normal one.
+ */
+const TARGET_BUDGET_MULTIPLIER = 3;
+/** setTimeout's 32-bit ceiling; beyond this it silently clamps to 1ms. */
+const MAX_CDP_TIMEOUT_MS = 2_147_483_647;
 
 /**
  * Upper bound on any single CDP round-trip. Override with CDP_TIMEOUT_MS.
@@ -34,7 +46,11 @@ function cdpTimeoutMs(): number {
   const raw = process.env.CDP_TIMEOUT_MS;
   if (!raw) return DEFAULT_CDP_TIMEOUT_MS;
   const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) return DEFAULT_CDP_TIMEOUT_MS;
+  if (!Number.isFinite(n) || n < 1) return DEFAULT_CDP_TIMEOUT_MS;
+  // setTimeout clamps anything past the 32-bit ceiling to 1ms, which would fire
+  // instantly and report "timed out after 2147483648ms" — the exact failure the
+  // validation exists to prevent.
+  if (n > MAX_CDP_TIMEOUT_MS) return DEFAULT_CDP_TIMEOUT_MS;
   return n;
 }
 
@@ -95,6 +111,11 @@ export function classifyTarget(t: any): ConnectionSource | null {
   // The desktop app loads morgen://./app.html.
   if (url.startsWith("morgen://")) return "electron";
 
+  // The web app is checked before the app.html fallback: web.morgen.so/app.html
+  // is a web tab, not the desktop app, and misreading it would mislabel the
+  // source in `morgen auth` output and in session.json.
+  if (url.includes("morgen.so")) return "chrome";
+
   // Some builds surface a bare app.html path instead of the morgen:// scheme.
   // It must still be Morgen's: a bare `app.html` match is far too broad —
   // 1Password's extension serves
@@ -104,7 +125,6 @@ export function classifyTarget(t: any): ConnectionSource | null {
   // 1Password's localStorage then failed the whole refresh.
   if (url.includes("app.html") && /morgen/i.test(url)) return "electron";
 
-  if (url.includes("morgen.so")) return "chrome";
   return null;
 }
 
@@ -191,7 +211,72 @@ export async function isMorgenRunning(port = DEFAULT_PORT): Promise<ConnectionSo
  * served. withTimeout bounds each attempt, so a wedge costs a timeout, not the
  * refresh.
  */
-async function withMorgenTarget<T>(
+/**
+ * Bound an attach whose client must be closed if it lands after the timeout.
+ *
+ * withTimeout only stops waiting — it cannot abort the connect. A slow-attaching
+ * renderer that completes after we gave up would otherwise orphan a live CDP
+ * websocket, and an open handle keeps the CLI's loop from draining: the command
+ * prints success and then hangs.
+ */
+async function attachWithTimeout(
+  host: string,
+  port: number,
+  target: any,
+  what: string,
+  ms: number
+): Promise<CDP.Client> {
+  const attach = CDP({ host, port, target }) as Promise<CDP.Client>;
+  const bounded = withTimeout(attach, what, ms);
+  bounded.catch(() => {
+    attach.then(
+      (client) => {
+        try {
+          void client.close();
+        } catch {
+          // ignore
+        }
+      },
+      () => {
+        // already rejected; nothing to close
+      }
+    );
+  });
+  return bounded;
+}
+
+/** Prefer a real diagnostic over a timeout when reporting why every target failed. */
+function bestError(errors: unknown[], port: number): Error {
+  if (errors.length === 0) return new Error(noTargetHint(port));
+  // A timeout says "a tab was busy"; anything else ("No morgen-refresh-token
+  // found") tells the user what to actually do, so surface that instead of
+  // whichever target happened to be tried last.
+  const substantive = errors.find(
+    (e) => e instanceof Error && !/timed out after/.test(e.message)
+  );
+  return (substantive ?? errors[errors.length - 1]) as Error;
+}
+
+/**
+ * Run `fn` against the best Morgen target that actually answers.
+ *
+ * Tries each viable target in rank order (Electron, then web), moving on when
+ * one fails or wedges, and always closing the client. Only the CDP work belongs
+ * in `fn` — keep network calls outside, so a backend failure is not retried
+ * against every tab.
+ *
+ * Retrying matters because these credentials can only be read with
+ * Runtime.evaluate against a page target (localStorage/IndexedDB have no
+ * browser-level CDP equivalent, unlike cookies). A page routes through its
+ * renderer and a busy renderer never answers, so committing to one target lets
+ * a single wedged tab fail a refresh that another open Morgen target could have
+ * served.
+ *
+ * One wall-clock budget covers the whole loop. Without it, each target could
+ * burn several timeouts (connect + one per evaluate) and N targets would take
+ * minutes of silence before any error.
+ */
+export async function withMorgenTarget<T>(
   port: number,
   fn: (client: CDP.Client, source: ConnectionSource) => Promise<T>
 ): Promise<T> {
@@ -201,17 +286,25 @@ async function withMorgenTarget<T>(
   const ranked = rankTargets(targets);
   if (ranked.length === 0) throw new Error(noTargetHint(port));
 
-  let lastError: unknown;
+  const perCallMs = cdpTimeoutMs();
+  const end = Date.now() + perCallMs * TARGET_BUDGET_MULTIPLIER;
+  const remaining = () => Math.max(0, end - Date.now());
+  const errors: unknown[] = [];
+
   for (const { source, target } of ranked) {
+    if (remaining() === 0) break;
     let client: CDP.Client | null = null;
     try {
-      client = await withTimeout(
-        CDP({ host, port, target }),
-        `connecting to the ${source} target`
+      client = await attachWithTimeout(
+        host,
+        port,
+        target,
+        `connecting to the ${source} target`,
+        Math.min(remaining(), perCallMs)
       );
       return await fn(client, source);
     } catch (err) {
-      lastError = err;
+      errors.push(err);
     } finally {
       if (client) {
         try {
@@ -222,7 +315,7 @@ async function withMorgenTarget<T>(
       }
     }
   }
-  throw lastError ?? new Error(noTargetHint(port));
+  throw bestError(errors, port);
 }
 
 /** Extract refresh token and device ID from an existing CDP client. */

--- a/src/morgen-cdp.ts
+++ b/src/morgen-cdp.ts
@@ -121,11 +121,27 @@ export function classifyTarget(t: any): ConnectionSource | null {
   // 1Password's extension serves
   // chrome-extension://<id>/app/app.html#/page/settings, which was being
   // classified as the Morgen desktop app and, since Electron ranks first,
-  // picked ahead of the real web.morgen.so tab. Reading credentials from
-  // 1Password's localStorage then failed the whole refresh.
-  if (url.includes("app.html") && /morgen/i.test(url)) return "electron";
+  // picked ahead of the real web.morgen.so tab.
+  //
+  // Match on origin+path only. Scanning the whole URL lets a query or fragment
+  // decide identity — https://example.com/app.html?next=morgen, or the same
+  // 1Password page at #/morgen/settings, would both come back Electron.
+  return isMorgenAppHtml(url) ? "electron" : null;
+}
 
-  return null;
+/** Is this an app.html served BY Morgen — judged on origin+path, not query/fragment? */
+function isMorgenAppHtml(url: string): boolean {
+  let scope: string;
+  try {
+    const u = new URL(url);
+    if (!u.pathname.includes("app.html")) return false;
+    scope = `${u.protocol}//${u.host}${u.pathname}`;
+  } catch {
+    // Not URL-parseable: fall back to the part before any query/fragment.
+    scope = url.split(/[?#]/)[0] ?? "";
+    if (!scope.includes("app.html")) return false;
+  }
+  return /morgen/i.test(scope);
 }
 
 /**
@@ -230,19 +246,32 @@ async function attachWithTimeout(
   const bounded = withTimeout(attach, what, ms);
   bounded.catch(() => {
     attach.then(
-      (client) => {
-        try {
-          void client.close();
-        } catch {
-          // ignore
-        }
-      },
+      (client) => closeQuietly(client),
       () => {
         // already rejected; nothing to close
       }
     );
   });
   return bounded;
+}
+
+/**
+ * Close without blocking and without throwing.
+ *
+ * Not awaited: a close that never settles would hang the caller after the work
+ * already succeeded. Its rejection is swallowed explicitly — `void client.close()`
+ * inside a try/catch only catches a SYNCHRONOUS throw, so a rejected close()
+ * escaped as an unhandledRejection.
+ */
+function closeQuietly(client: CDP.Client): void {
+  try {
+    const p = client.close() as unknown;
+    if (p && typeof (p as Promise<void>).catch === "function") {
+      (p as Promise<void>).catch(() => {});
+    }
+  } catch {
+    // ignore
+  }
 }
 
 /** Prefer a real diagnostic over a timeout when reporting why every target failed. */
@@ -281,14 +310,22 @@ export async function withMorgenTarget<T>(
   fn: (client: CDP.Client, source: ConnectionSource) => Promise<T>
 ): Promise<T> {
   const host = getCDPHost();
-  const targets = await CDP.List({ host, port });
+  const perCallMs = cdpTimeoutMs();
+  // The budget starts before discovery: a debug endpoint can accept the
+  // connection and never answer /json/list, which would hang before any retry
+  // logic was reached.
+  const end = Date.now() + perCallMs * TARGET_BUDGET_MULTIPLIER;
+  const remaining = () => Math.max(0, end - Date.now());
+
+  const targets = await withTimeout(
+    CDP.List({ host, port }),
+    "listing CDP targets",
+    Math.min(remaining(), perCallMs)
+  );
 
   const ranked = rankTargets(targets);
   if (ranked.length === 0) throw new Error(noTargetHint(port));
 
-  const perCallMs = cdpTimeoutMs();
-  const end = Date.now() + perCallMs * TARGET_BUDGET_MULTIPLIER;
-  const remaining = () => Math.max(0, end - Date.now());
   const errors: unknown[] = [];
 
   for (const { source, target } of ranked) {
@@ -302,17 +339,18 @@ export async function withMorgenTarget<T>(
         `connecting to the ${source} target`,
         Math.min(remaining(), perCallMs)
       );
-      return await fn(client, source);
+      // Bound fn too. Its own calls are bounded individually, but several of
+      // them (connect + creds + email) could otherwise outlast the budget the
+      // loop only re-checks BETWEEN targets.
+      return await withTimeout(
+        fn(client, source),
+        `reading from the ${source} target`,
+        remaining()
+      );
     } catch (err) {
       errors.push(err);
     } finally {
-      if (client) {
-        try {
-          await client.close();
-        } catch {
-          // ignore
-        }
-      }
+      if (client) closeQuietly(client);
     }
   }
   throw bestError(errors, port);

--- a/src/morgen-firebase.ts
+++ b/src/morgen-firebase.ts
@@ -13,10 +13,9 @@
  * See docs/investigations/2026-06-10_open-invites.md for the full reverse-engineering.
  */
 
-import CDP from "chrome-remote-interface";
 import { resolve } from "path";
 import { homedir } from "os";
-import { pickTarget, noTargetHint, withTimeout } from "./morgen-cdp";
+import { withMorgenTarget, withTimeout } from "./morgen-cdp";
 
 const DEFAULT_PORT = parseInt(process.env.CDP_PORT || "9253", 10);
 const SECURETOKEN_URL = "https://securetoken.googleapis.com/v1/token";
@@ -35,10 +34,6 @@ export interface FirebaseSession extends FirebaseCredentials {
   expiresAt: number; // Unix ms
 }
 
-function getCDPHost(): string {
-  return process.env.CDP_HOST || process.env.HOST_IP || "localhost";
-}
-
 /** Resolve the Firebase credential cache path at call time (tests redirect via env). */
 function getFirebaseFile(): string {
   return (
@@ -47,18 +42,18 @@ function getFirebaseFile(): string {
   );
 }
 
-/** Find the Morgen Electron/Chrome target and read Firebase auth state from IndexedDB. */
+/**
+ * Find the Morgen Electron/Chrome target and read Firebase auth state from IndexedDB.
+ *
+ * Goes through morgen-cdp's withMorgenTarget so this path gets the same
+ * Electron-then-web preference AND the same retry: it previously committed to a
+ * single target with an unbounded connect, so a wedged tab failed open-invite
+ * even with a healthy Morgen tab open. IndexedDB is read through the renderer
+ * too — more so than localStorage — so this path is the likelier victim, not
+ * the safer one.
+ */
 async function extractFromApp(port: number): Promise<FirebaseCredentials> {
-  const host = getCDPHost();
-  const targets = await CDP.List({ host, port });
-  // Share morgen-cdp's picker so the Firebase path honours the same
-  // Electron-then-web preference; it previously took whichever target matched
-  // first, which could land on the web app while the desktop app was running.
-  const picked = pickTarget(targets);
-  if (!picked) throw new Error(noTargetHint(port));
-
-  const client = await CDP({ host, port, target: picked.target });
-  try {
+  return withMorgenTarget(port, async (client) => {
     const { Runtime } = client;
     const result = await withTimeout(Runtime.evaluate({
       // firebase:authUser:<apiKey>:[DEFAULT] holds {uid, stsTokenManager:{refreshToken}, apiKey}
@@ -108,9 +103,7 @@ async function extractFromApp(port: number): Promise<FirebaseCredentials> {
       throw new Error("Incomplete Firebase credentials in Morgen app.");
     }
     return creds as FirebaseCredentials;
-  } finally {
-    await client.close();
-  }
+  });
 }
 
 /** Exchange a Firebase refresh token for a fresh ID token (no app/CDP required). */


### PR DESCRIPTION
Two rounds of adversarial review (subagent + codex). **The headline is a live bug I shipped in #9.**

## 1. 1Password was being treated as the Morgen desktop app

`classifyTarget` matched a bare `url.includes("app.html")`. Found by running `rankTargets` against the real browser:

```
electron :: chrome-extension://aeblfdkhhhdcdjpifhhbdiojplfjncoa/app/app.html#/page/settings   <- 1Password
chrome   :: https://web.morgen.so/
```

Electron ranks first, so `pickTarget` returned **1Password's settings page** ahead of the real Morgen tab — morgen then read `morgen-refresh-token` from 1Password's localStorage, found nothing, and failed the refresh with a healthy Morgen tab open the whole time. Live on `main` whenever that page is open.

Mine: #9 broadened the matcher to `app.html` to preserve the one case `morgen-firebase`'s matcher covered. That matcher had the same flaw, but it only affected the Firebase path — folding it into the shared `classifyTarget` spread it to session refresh too.

Now matched on **origin+path**, never query/fragment — codex showed `app.html#/morgen/settings` and `?next=morgen` would otherwise re-break it, which is exactly the 1Password shape.

## 2. One wedged target could fail a refresh another could serve

Morgen's credentials are in localStorage/IndexedDB, so they need `Runtime.evaluate` against a **page** target — no browser-level equivalent as there is for cookies. A busy renderer never answers, and 4 of 8 live page targets were wedged when measured (which ones drift over time). `rankTargets` + `withMorgenTarget` now try every viable target in order, bounded, closing each client.

`morgen-firebase` now routes through it too — it had the same single-target bug **and no timeout on its connect at all**, so `morgen auth` would survive a wedged tab while `open-invite` still failed. IndexedDB is more renderer-bound than localStorage, making it the likelier victim.

## What the reviewers caught in my own fixes

Both rounds found real defects in this branch, not just in the original code:

- **Connect-after-timeout leaked a client** — the same bug I'd fixed in superhuman-cli and not here. Demonstrated: a target attaching at 300ms under a 100ms timeout materialized and was never closed. An open handle stops the CLI's loop draining — prints success, then hangs.
- **My global budget was the per-call timeout**, so the first wedged target ate all of it and retry could never happen. My own resilience test caught it.
- **The budget didn't bound `fn`** — codex measured 193ms against a 150ms budget.
- **`CDP.List` sat outside the budget**, unbounded.
- **`void client.close()`** only catches synchronous throws → unhandledRejection on a rejected close.
- **`throw lastError` buried the actionable error** — users saw "connecting to the chrome target timed out" instead of "No morgen-refresh-token found". A diagnostic regression vs main.
- **`web.morgen.so/app.html` classified as Electron** (branch order), mislabeling `morgen auth` output and `session.json`.
- **`CDP_TIMEOUT_MS=2147483648`** passed validation but `setTimeout` clamps past 2³¹−1 to **1ms** — firing instantly and reporting "timed out after 2147483648ms", the exact failure the validation exists to prevent.
- **`CDP_TIMEOUT_MS` was captured at import time**, so tests (and callers) couldn't set it — while `getSessionFile()` right beside it resolves at call time for precisely that reason.

## Verification

**152 pass / 0 fail** (baseline 144/0). tsc **75 — identical to main** (this repo is not tsc-clean). `bun build --compile` clean.

Mutation-verified: capping `rankTargets` to one target fails the retry tests; restoring the whole-URL scan fails the classification tests.

Live against the real browser: `rankTargets` returns only `web.morgen.so`; 1Password → `null`; `web.morgen.so/app.html` → `chrome`; `morgen://./app.html` → `electron`; every dangerous `CDP_TIMEOUT_MS` falls back to 10000.

**Not covered by tests, stated plainly:** deadline overrun, hanging cleanup, `CDP.List` hanging, and Firebase multi-target retry are verified by reasoning and live probing rather than unit tests — faking them needs a full chrome-remote-interface double. Electron itself is unverified (no Morgen desktop app on this Linux box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZvrft29zMGgks5abHVtVK