### PR TITLE
fix: probe the Electron app then Chrome — morgen auth was broken on Linux

### DIFF
--- a/.planning/HYPOTHESES.md
+++ b/.planning/HYPOTHESES.md
@@ -1,0 +1,64 @@
+
+### Iteration: morgen-cli isWebTarget apex-fallback (2026-07-17)
+
+## Current Hypothesis
+H1: `isWebTarget` (`src/cdp-endpoint.ts:68-70`, `return hostMatches(url, "morgen.so")`)
+checks the apex domain instead of the real app UI hosts, so ANY subdomain of morgen.so
+classifies as `chrome` — including `book.morgen.so` (public booking page, confirmed real
+subdomain used by Open Invites per docs/investigations/2026-06-10_open-invites.md:31),
+`api.morgen.so` (REST API host, src/morgen-api.ts:12), `accounts.morgen.so` (illustrative
+impostor example from the bug report), and `morgen.so/blog`. Since Electron never wins on
+Linux (no desktop app), `isMorgenRunning`/`pickTarget` picks the first `chrome`-classified
+page target — an impostor tab left open beats or masks the real web.morgen.so tab, and
+`withMorgenTarget` attaches and runs localStorage-reading JS in it.
+
+## Evidence: real app hosts (from codebase, not taste)
+- `web.morgen.so` — the WEB_APP_URL const (src/cdp-endpoint.ts:98), confirmed live on
+  CDP port 9222 right now: `page https://web.morgen.so/` (real logged-in tab, verified via
+  `env -u CDP_PORT curl -s http://localhost:9222/json`).
+- `app.morgen.so` — documented legacy host in the existing test
+  (src/__tests__/morgen-target.test.ts:83-88, "morgen.so is the web app, on any subdomain"
+  — app.morgen.so is called out explicitly as "the older host" that must still classify).
+- NOT app hosts (real subdomains serving something other than the logged-in app UI):
+  `api.morgen.so` (REST API, src/morgen-api.ts:12, src/open-invite.ts:18),
+  `book.morgen.so` (public booking pages, no login required, src/open-invite.ts:19,
+  docs/investigations/2026-06-10_open-invites.md:31),
+  `platform.morgen.so` (API key portal, README.md:16),
+  `ai.cf.morgen.so` (chat backend, src/chat.ts:24),
+  `docs.morgen.so` (docs site, src/types.ts:4).
+- No `accounts.morgen.so` host appears anywhere in the codebase — it is illustrative of
+  the bug class, not a confirmed real host, but the fix (allowlist) excludes it regardless.
+
+## Hypothesis Log
+| # | Hypothesis | Test | Result |
+|---|-----------|------|--------|
+| H1 | apex-domain match in isWebTarget causes false positives on book/api/accounts/blog subdomains, which pickTarget then classifies as "chrome" and withMorgenTarget attaches credential JS to | New regression test in src/__tests__/morgen-target.test.ts: classifyTarget on book.morgen.so, api.morgen.so, accounts.morgen.so, morgen.so/blog must NOT be "chrome" | CONFIRMED — pre-fix, `https://book.morgen.so/abc123` classified as `"chrome"` (assertion `not.toBe("chrome")` failed, received "chrome"); test suite: 1 fail. |
+
+### Failing output (pre-fix)
+```
+✗ classifyTarget > REGRESSION: non-app morgen.so subdomains are NOT the web app
+  expect(classifyTarget(page("https://book.morgen.so/abc123"))).not.toBe("chrome")
+  Expected: not "chrome"
+
+ 31 pass
+ 1 fail
+```
+
+### Fix
+Replaced the apex `hostMatches(url, "morgen.so")` with an explicit allowlist of the two
+documented app hosts: `WEB_APP_HOSTS = ["web.morgen.so", "app.morgen.so"]`, checked via
+`WEB_APP_HOSTS.some((host) => hostMatches(url, host))`. `hostMatches` still does the
+subdomain/canonicalization/scheme work per-host, so `web.morgen.so.` (trailing dot) and
+`foo.web.morgen.so` still match, but `api.morgen.so`, `book.morgen.so`,
+`accounts.morgen.so`, and bare `morgen.so` no longer do.
+
+### Post-fix verification
+- New regression test: 32 pass / 0 fail in src/__tests__/morgen-target.test.ts.
+- Full suite: `bun test` → 161 pass / 1 skip / 0 fail (was 160 pass baseline + 1 new test).
+- `bunx tsc --noEmit --pretty false 2>&1 | grep -c "error TS"` → 75 (unchanged from baseline).
+- Required real shapes, spot-checked directly against classifyTarget: `morgen://./app.html`
+  → electron; `file:///opt/Morgen/resources/app.html` → electron; `https://web.morgen.so/`
+  → chrome; `https://app.morgen.so/tasks` → chrome; `https://web.morgen.so./calendar`
+  (FQDN trailing dot) → chrome. All OK.
+- Cross-repo invariant: `diff <(sed -n '/END PRODUCT BLOCK/,$p' morgen-cli/.../src/cdp-endpoint.ts) <(sed -n '/END PRODUCT BLOCK/,$p' superhuman-cli/.../src/cdp-endpoint.ts)` → empty (exit 0). The fix is entirely inside the PRODUCT BLOCK, so no drift.
+

--- a/.planning/HYPOTHESES.md
+++ b/.planning/HYPOTHESES.md
@@ -62,3 +62,109 @@ subdomain/canonicalization/scheme work per-host, so `web.morgen.so.` (trailing d
   (FQDN trailing dot) → chrome. All OK.
 - Cross-repo invariant: `diff <(sed -n '/END PRODUCT BLOCK/,$p' morgen-cli/.../src/cdp-endpoint.ts) <(sed -n '/END PRODUCT BLOCK/,$p' superhuman-cli/.../src/cdp-endpoint.ts)` → empty (exit 0). The fix is entirely inside the PRODUCT BLOCK, so no drift.
 
+### Iteration: morgen-target.test.ts cross-file mock.module leak (2026-07-17)
+
+## Phase 0/1: Triage, Reproduce
+
+Confirmed on Linux: `morgen-target.test.ts` does a plain top-level
+`import { classifyTarget, pickTarget, rankTargets, noTargetHint, withTimeout } from "../morgen-cdp"`.
+Four files call bun's GLOBAL `mock.module`: `morgen-api.test.ts` and `chat.test.ts` both
+`mock.module("../morgen-cdp", () => ({ loadSession, saveSession, isMorgenRunning, authenticate,
+refreshSession, getSessionToken }))` — a stub object with NONE of classifyTarget/pickTarget/
+rankTargets/noTargetHint/withTimeout. `morgen-firebase.test.ts` and `morgen-cdp.test.ts` mock
+`chrome-remote-interface`, not `../morgen-cdp`, so they are not implicated. `morgen-cdp.test.ts`
+already dodges the exact same hazard (comment at line 30-31: "Import the REAL morgen-cdp module
+via absolute path with cache-busting query to avoid getting the stub mock set by other test files
+(chat.test.ts, morgen-api.test.ts)") — proof the hazard is known and already has a working pattern
+in-repo, just not applied to morgen-target.test.ts.
+
+Reproduced by forcing bun to run a mocking file before morgen-target.test.ts:
+```
+$ bun test src/__tests__/chat.test.ts src/__tests__/morgen-target.test.ts
+src/__tests__/morgen-target.test.ts:
+# Unhandled error between tests
+-------------------------------
+SyntaxError: Export named 'classifyTarget' not found in module
+'.../src/morgen-cdp.ts'.
+-------------------------------
+ 16 pass
+ 1 skip
+ 1 fail
+ 1 error
+Ran 18 tests across 2 files.
+```
+Exactly the macOS symptom, reproduced on Linux by controlling file order — bun's default
+alphabetical/discovery order on this machine happens to run `morgen-target.test.ts` before any
+mocking file, which is why the full suite is 161/0 here but the hazard is real.
+
+## Phase 2: Investigate — where do the 5 symbols live?
+
+`classifyTarget`, `rankTargets`, `withTimeout`, `noTargetHint` are defined in `src/cdp-endpoint.ts`
+and merely re-exported by `src/morgen-cdp.ts` (`export { classifyTarget, rankTargets, withTimeout,
+noTargetHint } from "./cdp-endpoint"`, morgen-cdp.ts:32-36). No test file mocks `../cdp-endpoint`
+(grep confirms only `../morgen-cdp` and `chrome-remote-interface` are ever passed to
+`mock.module`), so importing those 4 directly from `../cdp-endpoint` would sidestep the mock
+entirely and structurally cannot be poisoned by a `mock.module("../morgen-cdp", ...)` stub
+anywhere in the suite, present or future.
+
+BUT `pickTarget` (`return rankTargets(targets)[0] ?? null`) is defined directly in
+`morgen-cdp.ts` itself (line 65), NOT re-exported from cdp-endpoint.ts — it has no "real home"
+outside the mocked module. Splitting the import (4 symbols from cdp-endpoint, 1 from morgen-cdp)
+would still leave pickTarget exposed to the same hazard, and is also less uniform/harder to reason
+about than one mechanism for all 5.
+
+Decision: use the SAME cache-busting absolute-import pattern morgen-cdp.test.ts already uses,
+applied to `../morgen-cdp` for all 5 symbols. This is simplest (one mechanism, not two), matches
+an already-reviewed and working in-repo precedent exactly, and is robust to `pickTarget` not
+existing in cdp-endpoint.ts. Query string must differ from morgen-cdp.test.ts's `?test-cdp` (e.g.
+`?test-target`) since bun's module cache key includes the query.
+
+## Current Hypothesis
+H1: Replacing morgen-target.test.ts's static `import { classifyTarget, pickTarget, rankTargets,
+noTargetHint, withTimeout } from "../morgen-cdp"` with a cache-busting dynamic
+`await import(resolve(import.meta.dir, "../morgen-cdp.ts") + "?test-target")`, matching
+morgen-cdp.test.ts's established pattern, makes morgen-target.test.ts immune to any
+`mock.module("../morgen-cdp", ...)` set by chat.test.ts/morgen-api.test.ts regardless of file
+execution order, because bun's mock.module only intercepts the STATIC specifier `"../morgen-cdp"`
+resolved through the module registry at its ORIGINAL (non-cache-busted) cache key — a fresh
+`import()` with an appended query string is a different cache key.
+
+## Hypothesis Log
+| # | Hypothesis | Test | Result |
+|---|-----------|------|--------|
+| H1 | cache-busting dynamic import of ../morgen-cdp.ts (same pattern as morgen-cdp.test.ts) makes morgen-target.test.ts immune to the mock.module leak from chat.test.ts/morgen-api.test.ts, regardless of order | Forced order `bun test chat.test.ts morgen-target.test.ts` before and after fix; also `bun test morgen-api.test.ts morgen-target.test.ts` after fix | CONFIRMED |
+
+### Fix applied and verified
+
+`src/__tests__/morgen-target.test.ts`: replaced the static
+`import { classifyTarget, pickTarget, rankTargets, noTargetHint, withTimeout } from "../morgen-cdp"`
+with a cache-busting dynamic import identical in shape to morgen-cdp.test.ts's existing pattern —
+`const mod = await import(resolve(import.meta.dir, "../morgen-cdp.ts") + "?test-target")`, then
+destructuring the 5 symbols off `mod` with `typeof import("../morgen-cdp").X` casts for type
+safety. `hostMatches` (from `../cdp-endpoint`, never mocked) is left as a plain static import,
+unchanged. No source file touched — one test file only.
+
+### Post-fix verification
+- Regression order, BEFORE fix (pasted above): `bun test chat.test.ts morgen-target.test.ts` →
+  16 pass / 1 skip / 1 fail / 1 error, `SyntaxError: Export named 'classifyTarget' not found`.
+- Regression order, AFTER fix: `bun test chat.test.ts morgen-target.test.ts` → 48 pass / 1 skip /
+  0 fail.
+- Second hazard order (the other mocking file), AFTER fix: `bun test morgen-api.test.ts
+  morgen-target.test.ts` → 35 pass / 0 fail.
+- Full suite, normal order: `bun test` → 161 pass / 1 skip / 0 fail (baseline held, no
+  regression, no new tests added this iteration).
+- `bunx tsc --noEmit --pretty false 2>&1 | grep -c "error TS"` → 75 (== main baseline, unchanged).
+
+### Structural note (not fixed this iteration, per scope)
+This fix AVOIDS the hazard for morgen-target.test.ts specifically; it does not make the hazard
+structurally impossible suite-wide. `morgen-firebase.test.ts` and `morgen-cdp.test.ts` mock
+`chrome-remote-interface` (not `../morgen-cdp`), so they don't collide with `chat.test.ts` /
+`morgen-api.test.ts`'s `../morgen-cdp` mocks, and `morgen-cdp.test.ts` already self-protects via
+the same cache-busting pattern. But any FUTURE test file that does a plain static
+`import ... from "../morgen-cdp"` (or `"../cdp-endpoint"`, if that ever gets mocked) reintroduces
+this exact class of order-dependent flake with no lint/CI guard against it. A structural fix
+(e.g. `afterEach(() => mock.restore())` in the two mocking files, or a bunfig.toml
+`preload`-based per-file module registry reset) was NOT attempted — out of scope for this single
+hypothesis per the one-hypothesis-per-invocation rule, and would touch shared test infra beyond
+the 1-file budget used here. Flagging for a follow-up iteration.
+

--- a/src/__tests__/morgen-target.test.ts
+++ b/src/__tests__/morgen-target.test.ts
@@ -207,6 +207,37 @@ describe("hostMatches — endpoint identity must not be forgeable", () => {
     expect(hostMatches("not a url", "morgen.so")).toBe(false);
   });
 
+  test("an http(s) page can never be the Electron desktop app", () => {
+    // Electron ranks FIRST, so a false positive here beats the genuine tab and
+    // gets credential-reading JS run in the impostor. An earlier cut matched
+    // /morgen/i across origin+path and accepted every one of these.
+    for (const url of [
+      "https://evil.example/morgen/app.html",
+      "https://morgen.so.evil.example/app.html",
+      "https://cdn.example/assets/morgen/app.html",
+      "http://localhost:8080/morgen/app.html",
+      "chrome-extension://abc/app/app.html",
+    ]) {
+      expect(classifyTarget({ type: "page", url })).toBeNull();
+    }
+  });
+
+  test("the real desktop app still classifies — a false negative breaks auth", () => {
+    expect(classifyTarget({ type: "page", url: "morgen://./app.html" })).toBe("electron");
+    expect(
+      classifyTarget({ type: "page", url: "file:///opt/Morgen/resources/app.html" })
+    ).toBe("electron");
+  });
+
+  test("an impostor never outranks the real tab", () => {
+    const ranked = rankTargets([
+      { type: "page", url: "https://evil.example/morgen/app.html" },
+      { type: "page", url: "https://web.morgen.so/" },
+    ]);
+    expect(ranked[0]?.source).toBe("chrome");
+    expect((ranked[0]?.target as any).url).toBe("https://web.morgen.so/");
+  });
+
   test("classifyTarget inherits the hardening", () => {
     expect(classifyTarget({ type: "page", url: "https://morgen.so.evil.example/" })).toBeNull();
     expect(classifyTarget({ type: "page", url: "https://web.morgen.so/" })).toBe("chrome");

--- a/src/__tests__/morgen-target.test.ts
+++ b/src/__tests__/morgen-target.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import {
-  classifyTarget,
-  pickTarget,
-  rankTargets,
-  noTargetHint,
-  withTimeout,
-} from "../morgen-cdp";
+import { resolve } from "path";
 import { hostMatches } from "../cdp-endpoint";
+
+// Import the REAL morgen-cdp module via absolute path with cache-busting query
+// to avoid getting the stub mock set by other test files (chat.test.ts,
+// morgen-api.test.ts), which call mock.module("../morgen-cdp", ...) globally.
+// Same pattern as morgen-cdp.test.ts; see comment there for rationale.
+const cdpModulePath = resolve(import.meta.dir, "../morgen-cdp.ts");
+const mod = await import(cdpModulePath + "?test-target");
+const classifyTarget = mod.classifyTarget as typeof import("../morgen-cdp").classifyTarget;
+const pickTarget = mod.pickTarget as typeof import("../morgen-cdp").pickTarget;
+const rankTargets = mod.rankTargets as typeof import("../morgen-cdp").rankTargets;
+const noTargetHint = mod.noTargetHint as typeof import("../morgen-cdp").noTargetHint;
+const withTimeout = mod.withTimeout as typeof import("../morgen-cdp").withTimeout;
 
 describe("rankTargets", () => {
   const page = (url: string) => ({ type: "page", url });

--- a/src/__tests__/morgen-target.test.ts
+++ b/src/__tests__/morgen-target.test.ts
@@ -80,11 +80,27 @@ describe("classifyTarget", () => {
     expect(classifyTarget(page("https://example.com/app.html"))).toBeNull();
   });
 
-  test("morgen.so is the web app, on any subdomain", () => {
+  test("morgen.so is the web app, on the app hosts", () => {
     // web.morgen.so is what the app actually serves today; app.morgen.so is the
-    // older host. The matcher keys on the bare domain, so both must classify.
+    // older host. Both must classify.
     expect(classifyTarget(page("https://web.morgen.so/"))).toBe("chrome");
     expect(classifyTarget(page("https://app.morgen.so/calendar"))).toBe("chrome");
+  });
+
+  test("REGRESSION: non-app morgen.so subdomains are NOT the web app", () => {
+    // isWebTarget matched the bare apex domain, so ANY subdomain of morgen.so —
+    // including real, public, logged-out pages a user routinely has open —
+    // classified as "chrome". isMorgenRunning then reported Morgen "running" off
+    // a blog tab, and withMorgenTarget attached and ran localStorage-reading JS
+    // in it. book.morgen.so (public booking links, see
+    // docs/investigations/2026-06-10_open-invites.md) and api.morgen.so (the
+    // REST API host, src/morgen-api.ts) are real, confirmed subdomains that are
+    // NOT the logged-in app UI.
+    expect(classifyTarget(page("https://book.morgen.so/abc123"))).not.toBe("chrome");
+    expect(classifyTarget(page("https://api.morgen.so/"))).not.toBe("chrome");
+    expect(classifyTarget(page("https://accounts.morgen.so/login"))).not.toBe("chrome");
+    expect(classifyTarget(page("https://morgen.so/blog/some-post"))).not.toBe("chrome");
+    expect(classifyTarget(page("https://morgen.so/"))).not.toBe("chrome");
   });
 
   test("non-page targets are never classified", () => {

--- a/src/__tests__/morgen-target.test.ts
+++ b/src/__tests__/morgen-target.test.ts
@@ -6,6 +6,7 @@ import {
   noTargetHint,
   withTimeout,
 } from "../morgen-cdp";
+import { hostMatches } from "../cdp-endpoint";
 
 describe("rankTargets", () => {
   const page = (url: string) => ({ type: "page", url });
@@ -180,5 +181,34 @@ describe("noTargetHint", () => {
 
   test("win32 suggests the exe", () => {
     expect(noTargetHint([9253, 9222], "win32")).toContain("Morgen.exe");
+  });
+});
+
+describe("hostMatches — endpoint identity must not be forgeable", () => {
+  test("accepts the domain and its subdomains", () => {
+    expect(hostMatches("https://morgen.so/", "morgen.so")).toBe(true);
+    expect(hostMatches("https://web.morgen.so/calendar", "morgen.so")).toBe(true);
+  });
+
+  test("rejects suffix-confusion hosts", () => {
+    // The bug this guards: includes("morgen.so") matched all of these, and the
+    // winning target gets credential-reading JS executed in it.
+    expect(hostMatches("https://morgen.so.evil.example/", "morgen.so")).toBe(false);
+    expect(hostMatches("https://notmorgen.so/", "morgen.so")).toBe(false);
+  });
+
+  test("rejects query/fragment mentions", () => {
+    expect(hostMatches("https://evil.example/?next=morgen.so", "morgen.so")).toBe(false);
+    expect(hostMatches("https://evil.example/#morgen.so", "morgen.so")).toBe(false);
+  });
+
+  test("rejects non-http(s) schemes and unparseable input", () => {
+    expect(hostMatches("file:///morgen.so/app.html", "morgen.so")).toBe(false);
+    expect(hostMatches("not a url", "morgen.so")).toBe(false);
+  });
+
+  test("classifyTarget inherits the hardening", () => {
+    expect(classifyTarget({ type: "page", url: "https://morgen.so.evil.example/" })).toBeNull();
+    expect(classifyTarget({ type: "page", url: "https://web.morgen.so/" })).toBe("chrome");
   });
 });

--- a/src/__tests__/morgen-target.test.ts
+++ b/src/__tests__/morgen-target.test.ts
@@ -159,7 +159,7 @@ describe("withTimeout", () => {
 describe("noTargetHint", () => {
   test("names both routes on every platform", () => {
     for (const platform of ["darwin", "linux", "win32"]) {
-      const hint = noTargetHint(9253, platform);
+      const hint = noTargetHint([9253, 9222], platform);
       expect(hint).toContain("Desktop app:");
       expect(hint).toContain("Web app:");
       expect(hint).toContain("9253");
@@ -167,18 +167,18 @@ describe("noTargetHint", () => {
   });
 
   test("linux does not suggest a macOS app bundle", () => {
-    const hint = noTargetHint(9253, "linux");
+    const hint = noTargetHint([9253, 9222], "linux");
     expect(hint).not.toContain("/Applications/");
     expect(hint).toContain("morgen --remote-debugging-port=9253");
   });
 
   test("darwin suggests the app bundle", () => {
-    expect(noTargetHint(9253, "darwin")).toContain(
+    expect(noTargetHint([9253, 9222], "darwin")).toContain(
       "/Applications/Morgen.app/Contents/MacOS/Morgen"
     );
   });
 
   test("win32 suggests the exe", () => {
-    expect(noTargetHint(9253, "win32")).toContain("Morgen.exe");
+    expect(noTargetHint([9253, 9222], "win32")).toContain("Morgen.exe");
   });
 });

--- a/src/cdp-endpoint.ts
+++ b/src/cdp-endpoint.ts
@@ -160,8 +160,21 @@ export function hostMatches(url: string, domain: string): boolean {
     return false;
   }
   if (u.protocol !== "https:" && u.protocol !== "http:") return false;
-  const h = u.hostname.toLowerCase();
-  const d = domain.toLowerCase();
+
+  // Canonicalize before comparing. A fully qualified name carries a root dot —
+  // "web.morgen.so." is the SAME DNS name as "web.morgen.so", and the WHATWG
+  // parser preserves it. Rejecting it would exclude a genuine logged-in tab and
+  // report "no target": a false negative here breaks auth outright, which is
+  // worse than the substring hole this function replaced.
+  const canon = (h: string) => h.toLowerCase().replace(/\.$/, "");
+  const h = canon(u.hostname);
+  const d = canon(domain);
+
+  // An empty host, or a leading empty label (".morgen.so"), is not a real name.
+  if (!h || !d || h.startsWith(".")) return false;
+
+  // Note: userinfo cannot fool this — new URL("https://morgen.so@evil.example/")
+  // has hostname "evil.example", and a port lives outside hostname.
   return h === d || h.endsWith(`.${d}`);
 }
 
@@ -266,8 +279,14 @@ export function resetEndpointCache(): void {
  *
  * Targets are always listed fresh, even on the cached-port path.
  */
-export async function discoverEndpoint(): Promise<Endpoint> {
+export async function discoverEndpoint(remaining?: () => number): Promise<Endpoint> {
   const host = getCDPHost();
+  // Every List is bounded by the SMALLER of one round-trip and whatever the
+  // caller has left. Without the caller's budget, discovery hands each probe a
+  // fresh full timeout and can outlast the very deadline the caller started
+  // before calling us — leaving zero time to attach to the target it just found.
+  const budget = () =>
+    remaining ? Math.min(remaining(), cdpTimeoutMs()) : cdpTimeoutMs();
 
   // A cached port is a hint, not a verdict. The app can move between
   // deployments inside one process — quit Electron on its port, open the web
@@ -280,7 +299,8 @@ export async function discoverEndpoint(): Promise<Endpoint> {
     try {
       const targets = await withTimeout(
         CDP.List({ host, port }) as Promise<any[]>,
-        `listing targets on port ${port}`
+        `listing targets on port ${port}`,
+        budget()
       );
       if (rankTargets(targets).length > 0) return { port, targets };
       // Listed fine, but nothing of ours is there any more — re-listing it
@@ -297,11 +317,13 @@ export async function discoverEndpoint(): Promise<Endpoint> {
   const candidates = cdpPortCandidates();
   for (const port of candidates) {
     if (port === skip) continue;
+    if (remaining && remaining() <= 0) break;
     let targets: any[];
     try {
       targets = await withTimeout(
         CDP.List({ host, port }) as Promise<any[]>,
-        `listing targets on port ${port}`
+        `listing targets on port ${port}`,
+        budget()
       );
     } catch {
       continue; // not listening, or not answering — try the next candidate

--- a/src/cdp-endpoint.ts
+++ b/src/cdp-endpoint.ts
@@ -22,7 +22,7 @@
  * bare ECONNREFUSED unless the user knew to set CDP_PORT by hand.
  *
  * Ports (all overridable, see cdpPortCandidates):
- *   CDP_PORT           explicit single port; wins outright, skips probing
+ *   CDP_PORT           pin to one port (still listed; no other candidate tried)
  *   ELECTRON_CDP_PORT  the desktop app's port      (default below)
  *   CHROME_CDP_PORT    Chrome/Chromium's port      (default below)
  */
@@ -177,8 +177,11 @@ function envPort(name: string): number | undefined {
 /**
  * CDP endpoints to probe, in preference order: the desktop app, then the browser.
  *
- * An explicit CDP_PORT wins outright — if the user names a port, probing past it
- * would be second-guessing them.
+ * An explicit CDP_PORT pins the list to that one port: if the user names a port,
+ * probing past it would be second-guessing them. It does NOT skip discovery —
+ * that port is still listed to find targets on it, so a firewalled host costs
+ * one cdpTimeoutMs before failing. Naming a port is not the same as promising
+ * something is there.
  */
 export function cdpPortCandidates(): number[] {
   const explicit = envPort("CDP_PORT");
@@ -280,11 +283,15 @@ export async function discoverEndpoint(): Promise<Endpoint> {
         `listing targets on port ${port}`
       );
       if (rankTargets(targets).length > 0) return { port, targets };
+      // Listed fine, but nothing of ours is there any more — re-listing it
+      // below would just repeat that answer, so skip it.
+      skip = port;
     } catch {
-      // fall through to rediscovery
+      // A transient error (EPIPE, a blip) is NOT evidence the port is wrong, so
+      // it stays a candidate: skipping it here failed the whole call while the
+      // port was healthy a moment later.
     }
     discoveredPort = null;
-    skip = port; // already tried; do not probe it twice
   }
 
   const candidates = cdpPortCandidates();

--- a/src/cdp-endpoint.ts
+++ b/src/cdp-endpoint.ts
@@ -64,9 +64,26 @@ function isElectronTarget(url: string): boolean {
   return false;
 }
 
+/**
+ * The app's own hosts — where the logged-in web UI is actually served.
+ *
+ * NOT the bare apex (`morgen.so`): that domain also serves real, public,
+ * logged-out pages a user routinely has open — `book.morgen.so` (booking
+ * links, see docs/investigations/2026-06-10_open-invites.md), `api.morgen.so`
+ * (the REST API, src/morgen-api.ts), `platform.morgen.so`, `ai.cf.morgen.so`,
+ * `docs.morgen.so`, and the marketing site at `morgen.so` itself. A false
+ * positive here beats or masks the real tab in rankTargets and gets
+ * credential-reading JavaScript run in the impostor's origin.
+ *
+ * web.morgen.so is what the app serves today (confirmed live: a logged-in tab
+ * on CDP port 9222). app.morgen.so is the older host, still documented and
+ * exercised by morgen-target.test.ts — some installs may still point at it.
+ */
+const WEB_APP_HOSTS = ["web.morgen.so", "app.morgen.so"];
+
 /** Is this target the product's web app in a browser? */
 function isWebTarget(url: string): boolean {
-  return hostMatches(url, "morgen.so");
+  return WEB_APP_HOSTS.some((host) => hostMatches(url, host));
 }
 
 /** Command that starts the desktop app with CDP, per platform. */

--- a/src/cdp-endpoint.ts
+++ b/src/cdp-endpoint.ts
@@ -59,7 +59,7 @@ function isElectronTarget(url: string): boolean {
 
 /** Is this target the product's web app in a browser? */
 function isWebTarget(url: string): boolean {
-  return url.includes("morgen.so");
+  return hostMatches(url, "morgen.so");
 }
 
 /** Command that starts the desktop app with CDP, per platform. */
@@ -96,7 +96,7 @@ export type ConnectionSource = "electron" | "chrome";
 
 const DEFAULT_CDP_TIMEOUT_MS = 10_000;
 /** setTimeout's 32-bit ceiling; beyond this it silently clamps to 1ms. */
-const MAX_CDP_TIMEOUT_MS = 2_147_483_647;
+export const MAX_CDP_TIMEOUT_MS = 2_147_483_647;
 
 /**
  * Upper bound on a single CDP round-trip.
@@ -135,6 +135,27 @@ export function withTimeout<T>(p: Promise<T>, what: string, ms = cdpTimeoutMs())
       }
     );
   });
+}
+
+/**
+ * Does `url`'s HOSTNAME equal `domain`, or is it a subdomain of it?
+ *
+ * Never a substring test. `includes("morgen.so")` also matches
+ * https://morgen.so.evil.example/ and https://evil.example/?next=morgen.so — and
+ * discovery hands the winning target to code that runs credential-reading
+ * JavaScript in it, so a forged identity is not cosmetic.
+ */
+export function hostMatches(url: string, domain: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return false;
+  }
+  if (u.protocol !== "https:" && u.protocol !== "http:") return false;
+  const h = u.hostname.toLowerCase();
+  const d = domain.toLowerCase();
+  return h === d || h.endsWith(`.${d}`);
 }
 
 /** Read a positive integer port from the environment, or undefined. */
@@ -238,17 +259,30 @@ export function resetEndpointCache(): void {
 export async function discoverEndpoint(): Promise<Endpoint> {
   const host = getCDPHost();
 
+  // A cached port is a hint, not a verdict. The app can move between
+  // deployments inside one process — quit Electron on its port, open the web
+  // app in Chrome — and a long-lived caller (the MCP server) would otherwise
+  // fail forever against a port that is now dead, or worse, one some other
+  // service has since bound.
+  let skip: number | null = null;
   if (discoveredPort !== null) {
     const port = discoveredPort;
-    const targets = await withTimeout(
-      CDP.List({ host, port }) as Promise<any[]>,
-      `listing targets on port ${port}`
-    );
-    return { port, targets };
+    try {
+      const targets = await withTimeout(
+        CDP.List({ host, port }) as Promise<any[]>,
+        `listing targets on port ${port}`
+      );
+      if (rankTargets(targets).length > 0) return { port, targets };
+    } catch {
+      // fall through to rediscovery
+    }
+    discoveredPort = null;
+    skip = port; // already tried; do not probe it twice
   }
 
   const candidates = cdpPortCandidates();
   for (const port of candidates) {
+    if (port === skip) continue;
     let targets: any[];
     try {
       targets = await withTimeout(

--- a/src/cdp-endpoint.ts
+++ b/src/cdp-endpoint.ts
@@ -1,0 +1,268 @@
+/**
+ * CDP Endpoint Discovery
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * DELIBERATELY NEAR-IDENTICAL to src/cdp-endpoint.ts in superhuman-cli.
+ * Only the PRODUCT BLOCK below differs. Keep it that way: both CLIs face the
+ * same problem, and one flow you can learn once is worth more than two clever
+ * ones. If you fix a bug here, fix it there.
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * Both products ship two deployments, and they are DIFFERENT CDP ENDPOINTS —
+ * not different tabs on one endpoint:
+ *
+ *   1. the Electron desktop app  — macOS; listens on its own debug port
+ *   2. Chrome/Chromium           — the web app; listens on the browser's port
+ *
+ * So: look for the Electron app first, then fall back to Chrome/Chromium.
+ *
+ * Getting this wrong is not theoretical. morgen-cli previously hardcoded a
+ * single port and never probed, so on Linux — where the desktop app does not
+ * exist and the web app runs in Chromium on 9222 — every command failed with a
+ * bare ECONNREFUSED unless the user knew to set CDP_PORT by hand.
+ *
+ * Ports (all overridable, see cdpPortCandidates):
+ *   CDP_PORT           explicit single port; wins outright, skips probing
+ *   ELECTRON_CDP_PORT  the desktop app's port      (default below)
+ *   CHROME_CDP_PORT    Chrome/Chromium's port      (default below)
+ */
+
+import CDP from "chrome-remote-interface";
+
+// ─── PRODUCT BLOCK — the only part that differs from the sibling CLI ─────────
+
+/** Human name, for error text. */
+const PRODUCT = "Morgen";
+
+/** The desktop app's debug port (`Morgen.app --remote-debugging-port=9253`). */
+const DEFAULT_ELECTRON_PORT = 9253;
+
+/** Chrome/Chromium's debug port, where the web app runs. */
+const DEFAULT_CHROME_PORT = 9222;
+
+/**
+ * Is this target the product's Electron desktop app?
+ *
+ * Morgen's desktop app loads morgen://./app.html. Some builds surface a bare
+ * app.html path instead, which must still be Morgen's — a bare "app.html" match
+ * is far too broad: 1Password's extension serves
+ * chrome-extension://<id>/app/app.html, and matching it made the CLI read
+ * credentials from 1Password's localStorage and fail the refresh.
+ *
+ * Matched on origin+path, never query/fragment — otherwise a route like
+ * app.html#/morgen/settings decides identity.
+ */
+function isElectronTarget(url: string): boolean {
+  if (url.startsWith("morgen://")) return true;
+  return isProductAppHtml(url, /morgen/i);
+}
+
+/** Is this target the product's web app in a browser? */
+function isWebTarget(url: string): boolean {
+  return url.includes("morgen.so");
+}
+
+/** Command that starts the desktop app with CDP, per platform. */
+function electronLaunchHint(port: number, platform: string = process.platform): string {
+  const bin =
+    platform === "darwin"
+      ? "/Applications/Morgen.app/Contents/MacOS/Morgen"
+      : platform === "win32"
+        ? "%LOCALAPPDATA%\\Programs\\Morgen\\Morgen.exe"
+        : "morgen"; // Linux: .deb/AppImage put `morgen` on PATH
+  return `${bin} --remote-debugging-port=${port}`;
+}
+
+/** app.html check, scoped to origin+path — never query/fragment. */
+function isProductAppHtml(url: string, productPattern: RegExp): boolean {
+  let scope: string;
+  try {
+    const u = new URL(url);
+    if (!u.pathname.includes("app.html")) return false;
+    scope = `${u.protocol}//${u.host}${u.pathname}`;
+  } catch {
+    scope = url.split(/[?#]/)[0] ?? "";
+    if (!scope.includes("app.html")) return false;
+  }
+  return productPattern.test(scope);
+}
+
+/** Where the web app lives, for error text. */
+const WEB_APP_URL = "https://web.morgen.so";
+
+// ─── END PRODUCT BLOCK — everything below is identical across both CLIs ──────
+
+export type ConnectionSource = "electron" | "chrome";
+
+const DEFAULT_CDP_TIMEOUT_MS = 10_000;
+/** setTimeout's 32-bit ceiling; beyond this it silently clamps to 1ms. */
+const MAX_CDP_TIMEOUT_MS = 2_147_483_647;
+
+/**
+ * Upper bound on a single CDP round-trip.
+ *
+ * Resolved at call time, not import time: a module-level const captures the env
+ * before a test (or a caller) can set it.
+ *
+ * Validated rather than trusted. parseInt("garbage") is NaN and
+ * setTimeout(fn, NaN) fires immediately; anything past the 32-bit ceiling is
+ * clamped to 1ms. Either would make every call "time out" instantly with a
+ * misleading message — the exact failure this guard exists to prevent.
+ */
+export function cdpTimeoutMs(): number {
+  const raw = process.env.CDP_TIMEOUT_MS;
+  if (!raw) return DEFAULT_CDP_TIMEOUT_MS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 1 || n > MAX_CDP_TIMEOUT_MS) return DEFAULT_CDP_TIMEOUT_MS;
+  return n;
+}
+
+/** Reject rather than wait forever — an unbounded CDP wait hangs the CLI silently. */
+export function withTimeout<T>(p: Promise<T>, what: string, ms = cdpTimeoutMs()): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${what} timed out after ${ms}ms — is the ${PRODUCT} tab responsive?`)),
+      ms
+    );
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      }
+    );
+  });
+}
+
+/** Read a positive integer port from the environment, or undefined. */
+function envPort(name: string): number | undefined {
+  const raw = process.env[name];
+  if (!raw) return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) return undefined;
+  return n;
+}
+
+/**
+ * CDP endpoints to probe, in preference order: the desktop app, then the browser.
+ *
+ * An explicit CDP_PORT wins outright — if the user names a port, probing past it
+ * would be second-guessing them.
+ */
+export function cdpPortCandidates(): number[] {
+  const explicit = envPort("CDP_PORT");
+  if (explicit) return [explicit];
+  return [
+    envPort("ELECTRON_CDP_PORT") ?? DEFAULT_ELECTRON_PORT,
+    envPort("CHROME_CDP_PORT") ?? DEFAULT_CHROME_PORT,
+  ];
+}
+
+export function getCDPHost(): string {
+  return process.env.CDP_HOST || process.env.HOST_IP || "localhost";
+}
+
+/** Classify a CDP target as the desktop app, the web app, or neither. */
+export function classifyTarget(t: any): ConnectionSource | null {
+  if (t?.type !== "page") return null;
+  const url: string | undefined = t.url;
+  if (!url) return null;
+  if (isElectronTarget(url)) return "electron";
+  if (isWebTarget(url)) return "chrome";
+  return null;
+}
+
+/**
+ * Rank every viable target, best first: the desktop app before the web app.
+ *
+ * Every one, not just the best. A CDP command routed through a page goes through
+ * its renderer, and a busy renderer never answers — measured, 4 of 8 live page
+ * targets were wedged at one point, and which ones drift over time. Committing
+ * to a single target lets one wedged tab fail a refresh another target could
+ * have served.
+ */
+export function rankTargets<T>(targets: T[]): Array<{ source: ConnectionSource; target: T }> {
+  const ranked: Array<{ source: ConnectionSource; target: T }> = [];
+  for (const source of ["electron", "chrome"] as const) {
+    for (const target of targets) {
+      if (classifyTarget(target) === source) ranked.push({ source, target });
+    }
+  }
+  return ranked;
+}
+
+/** Error text naming both routes — either satisfies the CLI, and only one exists per platform. */
+export function noTargetHint(ports: number[], platform: string = process.platform): string {
+  return (
+    `No ${PRODUCT} target found (probed port${ports.length > 1 ? "s" : ""} ${ports.join(", ")}).\n` +
+    "Start either route (quit the app first if already open, so the debug port takes effect):\n" +
+    `  Desktop app: ${electronLaunchHint(envPort("ELECTRON_CDP_PORT") ?? DEFAULT_ELECTRON_PORT, platform)}\n` +
+    `  Web app:     open ${WEB_APP_URL} in a browser started with --remote-debugging-port=${
+      envPort("CHROME_CDP_PORT") ?? DEFAULT_CHROME_PORT
+    }`
+  );
+}
+
+/** A discovered endpoint: the port, and the targets it is serving. */
+export interface Endpoint {
+  port: number;
+  targets: any[];
+}
+
+/**
+ * The PORT is cached for the process lifetime; the targets never are.
+ *
+ * Probing costs a round-trip per candidate, and the port will not move under a
+ * running CLI. Targets will: tabs open and close constantly, so a cached target
+ * list is stale the moment it is taken.
+ */
+let discoveredPort: number | null = null;
+
+/** Reset the discovery cache. Tests only. */
+export function resetEndpointCache(): void {
+  discoveredPort = null;
+}
+
+/**
+ * Find the CDP endpoint serving the product: the desktop app first, then the browser.
+ *
+ * Returns the first candidate port that has any viable target. A port that is
+ * listening but serving something else (a headless Chrome for another tool, say)
+ * is skipped rather than accepted — reachable is not the same as ours.
+ *
+ * Targets are always listed fresh, even on the cached-port path.
+ */
+export async function discoverEndpoint(): Promise<Endpoint> {
+  const host = getCDPHost();
+
+  if (discoveredPort !== null) {
+    const port = discoveredPort;
+    const targets = await withTimeout(
+      CDP.List({ host, port }) as Promise<any[]>,
+      `listing targets on port ${port}`
+    );
+    return { port, targets };
+  }
+
+  const candidates = cdpPortCandidates();
+  for (const port of candidates) {
+    let targets: any[];
+    try {
+      targets = await withTimeout(
+        CDP.List({ host, port }) as Promise<any[]>,
+        `listing targets on port ${port}`
+      );
+    } catch {
+      continue; // not listening, or not answering — try the next candidate
+    }
+    if (rankTargets(targets).length > 0) {
+      discoveredPort = port;
+      return { port, targets };
+    }
+  }
+
+  throw new Error(noTargetHint(candidates));
+}

--- a/src/cdp-endpoint.ts
+++ b/src/cdp-endpoint.ts
@@ -43,18 +43,25 @@ const DEFAULT_CHROME_PORT = 9222;
 /**
  * Is this target the product's Electron desktop app?
  *
- * Morgen's desktop app loads morgen://./app.html. Some builds surface a bare
- * app.html path instead, which must still be Morgen's — a bare "app.html" match
- * is far too broad: 1Password's extension serves
- * chrome-extension://<id>/app/app.html, and matching it made the CLI read
- * credentials from 1Password's localStorage and fail the refresh.
+ * ONLY the app's own scheme (morgen://) or a file:// path from its install dir
+ * can claim this. Deliberately NOT any http(s) URL that happens to mention the
+ * product: a remote page cannot be the local desktop app, and pretending
+ * otherwise is a hole, not a convenience.
  *
- * Matched on origin+path, never query/fragment — otherwise a route like
- * app.html#/morgen/settings decides identity.
+ * Electron ranks FIRST, so a false positive here does not merely add noise — it
+ * beats the genuine tab and gets credential-reading JavaScript executed in the
+ * impostor's origin. An earlier cut matched /morgen/i across origin+path, which
+ * accepted https://evil.example/morgen/app.html and ranked it ahead of the real
+ * web.morgen.so tab. Before that, a bare "app.html" match accepted 1Password's
+ * chrome-extension://<id>/app/app.html and broke refresh outright.
+ *
+ * A file:// URL requires local filesystem access to forge, which is a different
+ * threat model — by then the credential store is already readable.
  */
 function isElectronTarget(url: string): boolean {
   if (url.startsWith("morgen://")) return true;
-  return isProductAppHtml(url, /morgen/i);
+  if (url.startsWith("file://")) return isProductAppHtml(url, /morgen/i);
+  return false;
 }
 
 /** Is this target the product's web app in a browser? */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -346,7 +346,9 @@ ${colors.bold}OPTIONS${colors.reset}
   --calendars <names> Filter: only include these calendars (partial name match)
   --exclude-calendars <names> Filter: exclude these calendars (partial name match)
   --only-primary      Filter: only primary calendar (for chat)
-  --port <number>     CDP port (default: from CDP_PORT env or 9253)
+  --port <number>     CDP port. Default: probe the Morgen desktop app
+                      (ELECTRON_CDP_PORT, 9253) then Chrome/Chromium
+                      (CHROME_CDP_PORT, 9222). CDP_PORT pins one port.
   --json              Output as JSON array
   --ndjson            Output as newline-delimited JSON (one object per line); for
                       tasks --all, streams results per account as they arrive
@@ -355,10 +357,11 @@ ${colors.bold}OPTIONS${colors.reset}
   --version           Show version
 
 ${colors.bold}AUTH${colors.reset}
-  Connects to Chrome via CDP (port 9253 by default) and finds the Morgen tab
-  (web.morgen.so) to extract auth tokens.
+  Discovers the CDP endpoint — the Morgen desktop app first, then
+  Chrome/Chromium — and reads auth tokens from the Morgen target there.
 
-  Use --port to specify the CDP port (default: 9253 or CDP_PORT env).
+  Use --port to pin a CDP port. Otherwise: ELECTRON_CDP_PORT (9253) then
+  CHROME_CDP_PORT (9222); CDP_PORT pins one port and skips probing.
   Session tokens are cached in ~/.config/morgen-cli/session.json.
   Alternatively, set MORGEN_API_KEY for basic read + Morgen-native CRUD.
 

--- a/src/morgen-cdp.ts
+++ b/src/morgen-cdp.ts
@@ -6,8 +6,9 @@
  * full integration task CRUD through the Morgen API.
  *
  * Flow:
- *   1. Connect via CDP to Chrome (port 9253 by default)
- *   2. Find the morgen.so tab
+ *   1. Discover the CDP endpoint: the desktop app first, then Chrome
+ *      (see cdp-endpoint.ts)
+ *   2. Find the Morgen target there
  *   3. Read morgen-refresh-token and morgen-device-id from localStorage
  *   4. Exchange via POST /identity/refresh → session token (1h TTL)
  */

--- a/src/morgen-cdp.ts
+++ b/src/morgen-cdp.ts
@@ -236,15 +236,23 @@ export async function withMorgenTarget<T>(
         `connecting to the ${source} target`,
         Math.min(remaining(), perCallMs)
       );
-      // Give fn a PER-TARGET slice, not the whole remaining budget. fn's own
-      // calls are each bounded, but a multi-call callback (authenticate reads
-      // credentials AND the email) could chain several and consume everything —
-      // so the first wedged target starved every later one, defeating the retry
-      // this loop exists for. Reserving a slice keeps fallbacks reachable.
+      // fn gets the remaining budget, NOT a single per-call slice.
+      //
+      // A slice of perCallMs looks like the fix for "one wedged target starves
+      // the rest", and breaks authenticate() outright: its callback chains TWO
+      // bounded reads (credentials, then the email), each entitled to perCallMs,
+      // so a healthy pair legitimately needs 2x. Capping fn at 1x made a
+      // healthy-but-slow tab fail — proven: two 200ms reads under a 300ms cap
+      // time out, where the 900ms budget succeeds. The cure broke the path.
+      //
+      // Starvation is real but strictly less bad than breaking the happy path.
+      // A correct slice must be >= the max number of bounded calls any caller
+      // chains, which means fn's contract has to state that number — not a
+      // number guessed here.
       return await withTimeout(
         fn(client, source),
         `reading from the ${source} target`,
-        Math.min(remaining(), perCallMs)
+        remaining()
       );
     } catch (err) {
       errors.push(err);

--- a/src/morgen-cdp.ts
+++ b/src/morgen-cdp.ts
@@ -15,43 +15,35 @@
 import CDP from "chrome-remote-interface";
 import { resolve } from "path";
 import { homedir } from "os";
+import {
+  cdpPortCandidates,
+  cdpTimeoutMs,
+  classifyTarget,
+  discoverEndpoint,
+  getCDPHost,
+  noTargetHint,
+  rankTargets,
+  withTimeout,
+  type ConnectionSource,
+} from "./cdp-endpoint";
+
+export {
+  classifyTarget,
+  rankTargets,
+  withTimeout,
+  noTargetHint,
+  cdpPortCandidates,
+  type ConnectionSource,
+} from "./cdp-endpoint";
 
 const API_BASE = "https://api.morgen.so";
-const DEFAULT_PORT = parseInt(process.env.CDP_PORT || "9253", 10);
-const DEFAULT_CDP_TIMEOUT_MS = 10_000;
-/**
- * How many targets the retry loop may spend its budget on.
- *
- * The budget must exceed a single call's timeout or the first wedged target
- * consumes all of it and retry never happens — CDP_TIMEOUT_MS bounds one CALL,
- * so the loop gets a multiple of it. Realistically there are one or two Morgen
- * targets (rankTargets only returns Morgen ones, never every open tab), so this
- * bounds the pathological case without starving the normal one.
- */
-const TARGET_BUDGET_MULTIPLIER = 3;
-/** setTimeout's 32-bit ceiling; beyond this it silently clamps to 1ms. */
-const MAX_CDP_TIMEOUT_MS = 2_147_483_647;
-
-/**
- * Upper bound on any single CDP round-trip. Override with CDP_TIMEOUT_MS.
- *
- * Resolved at call time, not import time — the same reason getSessionFile() is:
- * a module-level const captures the env before a test (or a caller) can set it.
- *
- * Validated rather than trusted: parseInt("garbage") is NaN and
- * setTimeout(fn, NaN) fires immediately, so a typo would make every CDP call
- * "time out" instantly and every refresh fail with a misleading message.
- */
-function cdpTimeoutMs(): number {
-  const raw = process.env.CDP_TIMEOUT_MS;
-  if (!raw) return DEFAULT_CDP_TIMEOUT_MS;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || n < 1) return DEFAULT_CDP_TIMEOUT_MS;
-  // setTimeout clamps anything past the 32-bit ceiling to 1ms, which would fire
-  // instantly and report "timed out after 2147483648ms" — the exact failure the
-  // validation exists to prevent.
-  if (n > MAX_CDP_TIMEOUT_MS) return DEFAULT_CDP_TIMEOUT_MS;
-  return n;
+export interface SessionInfo {
+  token: string; // AI gateway token (for ai.cf.morgen.so)
+  apiToken: string; // Regular API token (for api.morgen.so)
+  refreshToken: string;
+  deviceId: string;
+  expiresAt: number; // Unix timestamp ms
+  source?: ConnectionSource; // "electron" or "chrome"
 }
 
 /**
@@ -64,110 +56,7 @@ function getSessionFile(): string {
 }
 
 /**
- * Get CDP host from environment or default to localhost
- */
-function getCDPHost(): string {
-  return process.env.CDP_HOST || process.env.HOST_IP || "localhost";
-}
-
-export type ConnectionSource = "electron" | "chrome";
-
-export interface SessionInfo {
-  token: string; // AI gateway token (for ai.cf.morgen.so)
-  apiToken: string; // Regular API token (for api.morgen.so)
-  refreshToken: string;
-  deviceId: string;
-  expiresAt: number; // Unix timestamp ms
-  source?: ConnectionSource; // "electron" or "chrome"
-}
-
-/**
- * Bound a CDP call. Credentials here live in localStorage/IndexedDB, so they
- * must be read with Runtime.evaluate against a page target — there is no
- * browser-level equivalent as there is for cookies. That means a wedged
- * renderer can swallow the call: observed live in a sibling tool, where a
- * playing YouTube tab never answered a CDP command while four other tabs
- * answered instantly. Without a bound, that is an indefinite hang and no error.
- */
-export function withTimeout<T>(p: Promise<T>, what: string, ms = cdpTimeoutMs()): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error(`${what} timed out after ${ms}ms — is the Morgen tab responsive?`)),
-      ms
-    );
-    p.then(
-      (v) => { clearTimeout(timer); resolve(v); },
-      (e) => { clearTimeout(timer); reject(e); }
-    );
-  });
-}
-
-/** Classify a CDP target as Morgen Electron, Chrome web app, or neither. */
-export function classifyTarget(t: any): ConnectionSource | null {
-  if (t.type !== "page") return null;
-  const url: string | undefined = t.url;
-  if (!url) return null;
-
-  // The desktop app loads morgen://./app.html.
-  if (url.startsWith("morgen://")) return "electron";
-
-  // The web app is checked before the app.html fallback: web.morgen.so/app.html
-  // is a web tab, not the desktop app, and misreading it would mislabel the
-  // source in `morgen auth` output and in session.json.
-  if (url.includes("morgen.so")) return "chrome";
-
-  // Some builds surface a bare app.html path instead of the morgen:// scheme.
-  // It must still be Morgen's: a bare `app.html` match is far too broad —
-  // 1Password's extension serves
-  // chrome-extension://<id>/app/app.html#/page/settings, which was being
-  // classified as the Morgen desktop app and, since Electron ranks first,
-  // picked ahead of the real web.morgen.so tab.
-  //
-  // Match on origin+path only. Scanning the whole URL lets a query or fragment
-  // decide identity — https://example.com/app.html?next=morgen, or the same
-  // 1Password page at #/morgen/settings, would both come back Electron.
-  return isMorgenAppHtml(url) ? "electron" : null;
-}
-
-/** Is this an app.html served BY Morgen — judged on origin+path, not query/fragment? */
-function isMorgenAppHtml(url: string): boolean {
-  let scope: string;
-  try {
-    const u = new URL(url);
-    if (!u.pathname.includes("app.html")) return false;
-    scope = `${u.protocol}//${u.host}${u.pathname}`;
-  } catch {
-    // Not URL-parseable: fall back to the part before any query/fragment.
-    scope = url.split(/[?#]/)[0] ?? "";
-    if (!scope.includes("app.html")) return false;
-  }
-  return /morgen/i.test(scope);
-}
-
-/**
- * Rank every viable Morgen target, best first: Electron before web (richer
- * credentials via the electronAPI bridge).
- *
- * Every one, not just the best: credentials here live in localStorage and
- * IndexedDB, so they must be read with Runtime.evaluate against a page target —
- * there is no browser-level equivalent as there is for cookies. A page routes
- * through its renderer, and a busy renderer never answers, so committing to a
- * single target means one wedged tab fails the whole refresh even when another
- * viable Morgen target is sitting right there. Measured in a sibling tool: 4 of
- * 8 live page targets were wedged at one point, and which ones drift over time.
- */
-export function rankTargets<T>(targets: T[]): Array<{ source: ConnectionSource; target: T }> {
-  const ranked: Array<{ source: ConnectionSource; target: T }> = [];
-  for (const source of ["electron", "chrome"] as const) {
-    for (const target of targets) {
-      if (classifyTarget(target) === source) ranked.push({ source, target });
-    }
-  }
-  return ranked;
-}
-
-/**
- * The single best Morgen target, or null.
+ * The single best target, or null.
  *
  * Prefer rankTargets when you can retry — this cannot survive a wedged tab.
  */
@@ -175,36 +64,24 @@ export function pickTarget<T>(targets: T[]): { source: ConnectionSource; target:
   return rankTargets(targets)[0] ?? null;
 }
 
-/** Platform-appropriate command for starting the Morgen desktop app with CDP. */
-function electronLaunchHint(port: number, platform: string = process.platform): string {
-  const bin =
-    platform === "darwin"
-      ? "/Applications/Morgen.app/Contents/MacOS/Morgen"
-      : platform === "win32"
-        ? "%LOCALAPPDATA%\\Programs\\Morgen\\Morgen.exe"
-        : "morgen"; // Linux: .deb/AppImage put `morgen` on PATH
-  return `${bin} --remote-debugging-port=${port}`;
-}
-
 /**
- * Error text for "no Morgen target". Names both routes — the desktop app
- * (Electron) and the web app in a browser — since either satisfies the CLI,
- * and only one of them exists on any given platform.
+ * How many targets the retry loop may spend its budget on.
+ *
+ * The budget must exceed a single call's timeout or the first wedged target
+ * consumes all of it and retry never happens — CDP_TIMEOUT_MS bounds one CALL,
+ * so the loop gets a multiple of it.
  */
-export function noTargetHint(port: number, platform: string = process.platform): string {
-  return (
-    `No Morgen target found on port ${port}.\n` +
-    "Start either route (quit the app first if already open, so the debug port takes effect):\n" +
-    `  Desktop app: ${electronLaunchHint(port, platform)}\n` +
-    `  Web app:     open https://web.morgen.so in a browser started with --remote-debugging-port=${port}`
-  );
-}
+const TARGET_BUDGET_MULTIPLIER = 3;
 
 /** Check if Morgen is reachable via CDP (Chrome with morgen.so tab or Electron app). */
-export async function isMorgenRunning(port = DEFAULT_PORT): Promise<ConnectionSource | false> {
+export async function isMorgenRunning(port?: number): Promise<ConnectionSource | false> {
   try {
-    const host = getCDPHost();
-    const targets = await CDP.List({ host, port });
+    if (port !== undefined) {
+      const targets = await CDP.List({ host: getCDPHost(), port });
+      return pickTarget(targets)?.source ?? false;
+    }
+    // No port named: probe the desktop app, then the browser.
+    const { targets } = await discoverEndpoint();
     return pickTarget(targets)?.source ?? false;
   } catch {
     return false;
@@ -275,8 +152,8 @@ function closeQuietly(client: CDP.Client): void {
 }
 
 /** Prefer a real diagnostic over a timeout when reporting why every target failed. */
-function bestError(errors: unknown[], port: number): Error {
-  if (errors.length === 0) return new Error(noTargetHint(port));
+function bestError(errors: unknown[], ports: number[]): Error {
+  if (errors.length === 0) return new Error(noTargetHint(ports));
   // A timeout says "a tab was busy"; anything else ("No morgen-refresh-token
   // found") tells the user what to actually do, so surface that instead of
   // whichever target happened to be tried last.
@@ -306,7 +183,7 @@ function bestError(errors: unknown[], port: number): Error {
  * minutes of silence before any error.
  */
 export async function withMorgenTarget<T>(
-  port: number,
+  port: number | undefined,
   fn: (client: CDP.Client, source: ConnectionSource) => Promise<T>
 ): Promise<T> {
   const host = getCDPHost();
@@ -317,14 +194,26 @@ export async function withMorgenTarget<T>(
   const end = Date.now() + perCallMs * TARGET_BUDGET_MULTIPLIER;
   const remaining = () => Math.max(0, end - Date.now());
 
-  const targets = await withTimeout(
-    CDP.List({ host, port }),
-    "listing CDP targets",
-    Math.min(remaining(), perCallMs)
-  );
+  // An explicit port is honoured as-is; otherwise probe the desktop app, then
+  // the browser. This is the whole point of cdp-endpoint: the two deployments
+  // are different ENDPOINTS, not different tabs on one endpoint.
+  let resolvedPort: number;
+  let targets: any[];
+  if (port !== undefined) {
+    resolvedPort = port;
+    targets = await withTimeout(
+      CDP.List({ host, port }) as Promise<any[]>,
+      "listing CDP targets",
+      Math.min(remaining(), perCallMs)
+    );
+  } else {
+    const endpoint = await discoverEndpoint();
+    resolvedPort = endpoint.port;
+    targets = endpoint.targets;
+  }
 
   const ranked = rankTargets(targets);
-  if (ranked.length === 0) throw new Error(noTargetHint(port));
+  if (ranked.length === 0) throw new Error(noTargetHint([resolvedPort]));
 
   const errors: unknown[] = [];
 
@@ -334,7 +223,7 @@ export async function withMorgenTarget<T>(
     try {
       client = await attachWithTimeout(
         host,
-        port,
+        resolvedPort,
         target,
         `connecting to the ${source} target`,
         Math.min(remaining(), perCallMs)
@@ -353,7 +242,7 @@ export async function withMorgenTarget<T>(
       if (client) closeQuietly(client);
     }
   }
-  throw bestError(errors, port);
+  throw bestError(errors, [resolvedPort]);
 }
 
 /** Extract refresh token and device ID from an existing CDP client. */
@@ -477,7 +366,7 @@ export async function refreshSession(): Promise<SessionInfo> {
  * Get a valid session token. Tries cached session first,
  * then extracts from running Morgen app or Chrome browser.
  */
-export async function getSessionToken(port = DEFAULT_PORT): Promise<string> {
+export async function getSessionToken(port?: number): Promise<string> {
   // Try cached session
   const cached = await loadSession();
   if (cached) return cached.token;
@@ -497,7 +386,7 @@ export async function getSessionToken(port = DEFAULT_PORT): Promise<string> {
  * Authenticate: extract credentials from running Morgen app or Chrome browser
  * and save session. Returns account info for display.
  */
-export async function authenticate(port = DEFAULT_PORT): Promise<{
+export async function authenticate(port?: number): Promise<{
   email: string;
   expiresAt: number;
   source: ConnectionSource;

--- a/src/morgen-cdp.ts
+++ b/src/morgen-cdp.ts
@@ -215,7 +215,7 @@ export async function withMorgenTarget<T>(
       Math.min(remaining(), perCallMs)
     );
   } else {
-    const endpoint = await discoverEndpoint();
+    const endpoint = await discoverEndpoint(remaining);
     resolvedPort = endpoint.port;
     targets = endpoint.targets;
   }

--- a/src/morgen-cdp.ts
+++ b/src/morgen-cdp.ts
@@ -18,6 +18,7 @@ import { homedir } from "os";
 import {
   cdpPortCandidates,
   cdpTimeoutMs,
+  MAX_CDP_TIMEOUT_MS,
   classifyTarget,
   discoverEndpoint,
   getCDPHost,
@@ -188,10 +189,16 @@ export async function withMorgenTarget<T>(
 ): Promise<T> {
   const host = getCDPHost();
   const perCallMs = cdpTimeoutMs();
+  // Cap the aggregate. cdpTimeoutMs accepts up to setTimeout's 32-bit ceiling,
+  // and multiplying an accepted value could push the budget past it — where the
+  // runtime clamps to ~1ms and every call "times out" instantly. That is the
+  // precise failure cdpTimeoutMs's own clamp exists to prevent; re-introducing
+  // it one multiplication downstream would be a poor joke.
+  const budgetMs = Math.min(perCallMs * TARGET_BUDGET_MULTIPLIER, MAX_CDP_TIMEOUT_MS);
   // The budget starts before discovery: a debug endpoint can accept the
   // connection and never answer /json/list, which would hang before any retry
   // logic was reached.
-  const end = Date.now() + perCallMs * TARGET_BUDGET_MULTIPLIER;
+  const end = Date.now() + budgetMs;
   const remaining = () => Math.max(0, end - Date.now());
 
   // An explicit port is honoured as-is; otherwise probe the desktop app, then

--- a/src/morgen-cdp.ts
+++ b/src/morgen-cdp.ts
@@ -236,13 +236,15 @@ export async function withMorgenTarget<T>(
         `connecting to the ${source} target`,
         Math.min(remaining(), perCallMs)
       );
-      // Bound fn too. Its own calls are bounded individually, but several of
-      // them (connect + creds + email) could otherwise outlast the budget the
-      // loop only re-checks BETWEEN targets.
+      // Give fn a PER-TARGET slice, not the whole remaining budget. fn's own
+      // calls are each bounded, but a multi-call callback (authenticate reads
+      // credentials AND the email) could chain several and consume everything —
+      // so the first wedged target starved every later one, defeating the retry
+      // this loop exists for. Reserving a slice keeps fallbacks reachable.
       return await withTimeout(
         fn(client, source),
         `reading from the ${source} target`,
-        remaining()
+        Math.min(remaining(), perCallMs)
       );
     } catch (err) {
       errors.push(err);

--- a/src/morgen-firebase.ts
+++ b/src/morgen-firebase.ts
@@ -17,7 +17,6 @@ import { resolve } from "path";
 import { homedir } from "os";
 import { withMorgenTarget, withTimeout } from "./morgen-cdp";
 
-const DEFAULT_PORT = parseInt(process.env.CDP_PORT || "9253", 10);
 const SECURETOKEN_URL = "https://securetoken.googleapis.com/v1/token";
 
 /** Firebase project the Morgen app syncs against (from the app bundle). */
@@ -52,7 +51,7 @@ function getFirebaseFile(): string {
  * too — more so than localStorage — so this path is the likelier victim, not
  * the safer one.
  */
-async function extractFromApp(port: number): Promise<FirebaseCredentials> {
+async function extractFromApp(port?: number): Promise<FirebaseCredentials> {
   return withMorgenTarget(port, async (client) => {
     const { Runtime } = client;
     const result = await withTimeout(Runtime.evaluate({
@@ -158,7 +157,7 @@ async function loadFirebaseSession(): Promise<FirebaseSession | null> {
  * id token when the cached one is near expiry; only falls back to CDP extraction when there is
  * no cached credential at all.
  */
-export async function getFirebaseSession(port = DEFAULT_PORT): Promise<FirebaseSession> {
+export async function getFirebaseSession(port?: number): Promise<FirebaseSession> {
   const cached = await loadFirebaseSession();
   if (cached?.refreshToken) {
     // Reuse a still-valid id token (5-min buffer); otherwise refresh app-independently.
@@ -181,7 +180,7 @@ export async function getFirebaseSession(port = DEFAULT_PORT): Promise<FirebaseS
 }
 
 /** Force re-extraction of Firebase credentials from the running app (for `auth`). */
-export async function authenticateFirebase(port = DEFAULT_PORT): Promise<FirebaseSession> {
+export async function authenticateFirebase(port?: number): Promise<FirebaseSession> {
   const creds = await extractFromApp(port);
   const session = await exchangeIdToken(creds);
   await saveFirebaseSession(session);


### PR DESCRIPTION
**`morgen auth` fails out of the box on Linux.** Not a latent risk — a bare `✗ ECONNREFUSED`.

## The bug

The CLI hardcoded **one** port (9253) and never probed. 9253 is Morgen.app's debug port on macOS; on Linux there is no desktop app and the web app runs in Chromium on **9222**. So nothing is ever found unless the user knows to set `CDP_PORT` by hand.

```
released v0.10.1, no CDP_PORT:  ✗ ECONNREFUSED
this branch,      no CDP_PORT:  {"email":"eddyhu@gmail.com",...,"source":"chrome"}
```

This is the bug the original *"make sure both electron and PWA routes work on Mac and Linux"* work was supposed to find. **It did not — because every test I ran passed `CDP_PORT=9222` explicitly.** The harness hid the very bug it existed to expose. All the earlier target-selection work (rankTargets, retry, the 1Password fix) was refining selection *inside a port that is not reachable on Linux by default*.

## The modelling error

The two deployments are different **CDP endpoints**, not different tabs on one endpoint. The old code treated Electron-vs-web as target classification within a single port — which only works if both happen to live there. Morgen had no notion of the Electron endpoint at all; its own docstring called 9253 *"Chrome (port 9253 by default)"*.

## The shape

New `src/cdp-endpoint.ts`, **byte-identical to superhuman-cli's file of the same name below the PRODUCT BLOCK** — 176 lines, same exported API, same order, same comments (edwinhu/superhuman-cli#29).

```
├─ PRODUCT BLOCK   ◄── the ONLY difference: name, ports, matchers, launch hint
└─ everything else ◄── identical in both repos
```

superhuman already had this probe (`discoverSuperhumanPort`); morgen simply never got one. Now they are the same code.

## Ports

| var | meaning |
|---|---|
| `CDP_PORT` | explicit single port — wins outright, skips probing |
| `ELECTRON_CDP_PORT` | Morgen.app (default 9253) |
| `CHROME_CDP_PORT` | Chrome/Chromium (default 9222) |

**9250 dropped** — on this machine it is a headless Chrome for an unrelated tool, which could bind a browser with no Morgen session.

## One design bug I caught in my own module

My first cut cached the **targets** alongside the port. A stale target list broke a firebase test outright — and in production it is worse: tabs open and close constantly, so a cached list is wrong the moment it is taken. Now **only the port is cached**; targets are always listed fresh.

## Verification

Live on Linux, no `CDP_PORT`: authenticates with `source: "chrome"`. Env layers: `CHROME_CDP_PORT=9222` works; `CDP_PORT=9222` works; a wrong `CHROME_CDP_PORT=9999` errors with `No Morgen target found (probed ports 9253, 9999)` plus both launch hints.

152 pass / 0 fail. tsc 75 — identical to main.

Electron (9253) remains unverified — no Morgen.app here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZvrft29zMGgks5abHVtVK