### PR TITLE
test: make the mock.module leak structurally impossible, not merely dodged

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,5 @@
+[test]
+# Runs before any test file is evaluated. Isolates the suite from the developer's
+# real machine state (logged-in morgen session, MORGEN_API_KEY in the shell).
+# See src/__tests__/helpers/preload.ts for the full rationale.
+preload = ["./src/__tests__/helpers/preload.ts"]

--- a/src/__tests__/chat.test.ts
+++ b/src/__tests__/chat.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mockMorgenCdp } from "./helpers/mock-morgen-cdp";
 import type {
   ChatMessage,
   ChatMessageToolCall,
@@ -11,14 +12,16 @@ import type {
 // Mock morgen-cdp BEFORE importing chat module
 let mockLoadSessionResult: { token: string; apiToken: string; refreshToken: string; deviceId: string; expiresAt: number } | null = null;
 
-mock.module("../morgen-cdp", () => ({
+// Stubs the auth surface only; every other morgen-cdp export stays real, so this
+// registration cannot break other test files' static imports. See the helper.
+await mockMorgenCdp({
   loadSession: () => Promise.resolve(mockLoadSessionResult),
   saveSession: async () => {},
   isMorgenRunning: async () => false,
   authenticate: async () => ({ email: "", expiresAt: 0, source: "electron" }),
   refreshSession: async () => { throw new Error("no stored session"); },
   getSessionToken: async () => "",
-}));
+});
 
 // Import chat functions after mock is set up
 const { parseSSEStream, sendChat } = await import("../chat");

--- a/src/__tests__/helpers/mock-morgen-cdp.ts
+++ b/src/__tests__/helpers/mock-morgen-cdp.ts
@@ -1,0 +1,46 @@
+import { mock } from "bun:test";
+import { resolve } from "path";
+
+type MorgenCdp = typeof import("../../morgen-cdp");
+
+/**
+ * Register a module mock for `src/morgen-cdp.ts` that is COMPLETE by construction.
+ *
+ * Why this helper exists
+ * ──────────────────────
+ * `mock.module` in bun is process-global and permanent for the whole `bun test`
+ * run: it is keyed by resolved module path, and it is NOT undone by
+ * `mock.restore()` (verified on bun 1.3.14 — `mock.restore()` restores spies
+ * only; a `mock.module` registration survives it). It also cannot be scoped to
+ * one test file. So whatever any test file registers for `../morgen-cdp` is what
+ * EVERY later-loading test file sees when it does a plain static
+ * `import { x } from "../morgen-cdp"`.
+ *
+ * That made incomplete stubs a platform-dependent landmine. A stub literal that
+ * omitted, say, `classifyTarget` caused any later file importing it to die with
+ *
+ *     SyntaxError: Export named 'classifyTarget' not found in module .../morgen-cdp.ts
+ *
+ * ...but only when bun happened to load the mocking file first. bun's file order
+ * differs between Linux and macOS, so the same commit was green on one and red on
+ * the other.
+ *
+ * The fix: never hand-write the stub's export surface. This helper spreads the
+ * REAL module (loaded via a cache-busting query so it is the genuine module even
+ * if another test file already registered a mock) and applies `overrides` on top.
+ * The registered mock therefore always carries the real module's full export
+ * surface, so a leak into another test file can never produce a missing-export
+ * SyntaxError. Overridden keys are stubbed; everything else stays real.
+ *
+ * Always use this instead of calling `mock.module("../morgen-cdp", ...)` directly.
+ * `src/__tests__/mock-isolation.test.ts` enforces that mechanically.
+ *
+ * @param overrides Partial stub. Typed against the real module, so you cannot
+ *                  stub an export that does not exist or with a wrong signature.
+ */
+export async function mockMorgenCdp(overrides: Partial<MorgenCdp>): Promise<void> {
+  const realPath = resolve(import.meta.dir, "../../morgen-cdp.ts");
+  // Cache-busting query => the genuine module, never a previously-registered mock.
+  const real = (await import(realPath + "?real-base")) as MorgenCdp;
+  mock.module(realPath, () => ({ ...real, ...overrides }));
+}

--- a/src/__tests__/helpers/preload.ts
+++ b/src/__tests__/helpers/preload.ts
@@ -1,0 +1,48 @@
+/**
+ * Test preload — runs once, before ANY test file is evaluated.
+ * Wired up in `bunfig.toml` under `[test] preload`.
+ *
+ * Purpose: make the test suite independent of the developer's real machine state.
+ *
+ * `morgen-cdp.loadSession()` resolves its path from `MORGEN_SESSION_FILE`, falling
+ * back to `~/.config/morgen-cli/session.json` — the developer's REAL logged-in
+ * session. Any test that exercises a code path calling `loadSession()` therefore
+ * behaved differently depending on whether the developer happened to be logged in.
+ *
+ * That was a live bug, not a hypothetical: `tools.test.ts`'s "calendarRead fetches
+ * events across all accounts" asserts an exact fetch count. With a real session on
+ * disk, `loadSession()` returned a token, auth took a different path, and the count
+ * went 2 -> 4. The suite was green on CI and on logged-out machines, and red on a
+ * logged-in one — with the outcome further scrambled by bun's file order, since
+ * `morgen-cdp.test.ts` sets `MORGEN_SESSION_FILE` process-wide at eval time and
+ * whether that landed before `tools.test.ts` depended on readdir order.
+ *
+ * `cli.test.ts` and `tasks.test.ts` had each already hand-rolled their own
+ * defensive override ("in case the parent suite set it"). Doing it per-file means
+ * every new test file must remember; this makes it true for all of them by default.
+ *
+ * Individual files may still point the var somewhere of their own (morgen-cdp.test.ts
+ * does, to exercise real session writes); this only guarantees the default is never
+ * the developer's real session.
+ */
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { resolve } from "path";
+
+const RUN_TMP_DIR = mkdtempSync(resolve(tmpdir(), "morgen-cli-testrun-"));
+
+// Point at a path inside a fresh temp dir. Nothing has written it, so the default
+// loadSession() result is null (logged out) — deterministic on every machine.
+process.env.MORGEN_SESSION_FILE = resolve(RUN_TMP_DIR, "session.json");
+
+// A real API key in the developer's shell must not leak into tests either; tests
+// that need one set it explicitly.
+delete process.env.MORGEN_API_KEY;
+
+process.on("exit", () => {
+  try {
+    rmSync(RUN_TMP_DIR, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});

--- a/src/__tests__/mock-isolation.test.ts
+++ b/src/__tests__/mock-isolation.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Guard tests for the module-mock isolation hazard.
+ *
+ * `mock.module` is process-global, permanent (survives `mock.restore()` on bun
+ * 1.3.14), and applies to every test file loaded afterwards. An incomplete stub
+ * for a module that other test files import statically is therefore a
+ * platform-dependent flake: green wherever bun loads the files in a lucky order,
+ * red elsewhere. See `helpers/mock-morgen-cdp.ts` for the full story.
+ *
+ * The first test below is the real guard: it reads source text, so it is
+ * order-independent and fails identically on every platform. The second is a
+ * best-effort canary on actual module state — it can only catch a leak when bun
+ * happens to load it after the offending file, which is exactly the coin-flip
+ * the first test exists to remove. Do not rely on the canary alone.
+ */
+
+const TEST_DIR = import.meta.dir;
+
+function testFiles(): string[] {
+  return readdirSync(TEST_DIR).filter((f) => f.endsWith(".test.ts"));
+}
+
+describe("mock.module isolation", () => {
+  test("no test file registers a raw mock.module for morgen-cdp", () => {
+    // A raw registration hand-writes the stub's export surface, which is how the
+    // missing-export SyntaxError gets reintroduced. Route it through
+    // mockMorgenCdp(), which spreads the real module and cannot be incomplete.
+    const offenders: string[] = [];
+    for (const file of testFiles()) {
+      if (file === "mock-isolation.test.ts") continue;
+      const src = readFileSync(resolve(TEST_DIR, file), "utf8");
+      // Matches mock.module("../morgen-cdp"), './morgen-cdp', with or without .ts
+      if (/mock\.module\(\s*["'`][^"'`]*morgen-cdp(\.ts)?["'`]/.test(src)) {
+        offenders.push(file);
+      }
+    }
+
+    expect(
+      offenders,
+      `These files call mock.module() on morgen-cdp directly. That stub leaks into ` +
+        `every later-loading test file and breaks any static import of an export it ` +
+        `omits. Use mockMorgenCdp() from ./helpers/mock-morgen-cdp instead.`,
+    ).toEqual([]);
+  });
+
+  test("a leaked morgen-cdp mock still exposes the real module's full export surface", async () => {
+    // Canary (see file header): only meaningful if a mocking file loaded before
+    // this one, which depends on bun's file order. When it does run after one,
+    // it asserts the property that matters end-to-end: whatever mock is
+    // registered, a plain static import of ANY real export must still resolve.
+    // This is what morgen-target.test.ts relies on.
+    const realPath = resolve(TEST_DIR, "../morgen-cdp.ts");
+    const real = await import(realPath + "?isolation-guard-real");
+    const asSeenByImporters = await import("../morgen-cdp");
+
+    const missing = Object.keys(real).filter((k) => !(k in asSeenByImporters));
+
+    expect(
+      missing,
+      `Exports present in the real morgen-cdp but missing from what importers ` +
+        `resolve. A registered module mock is incomplete; importing any of these ` +
+        `statically throws "Export named 'x' not found in module".`,
+    ).toEqual([]);
+  });
+});

--- a/src/__tests__/morgen-api.test.ts
+++ b/src/__tests__/morgen-api.test.ts
@@ -1,14 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mockMorgenCdp } from "./helpers/mock-morgen-cdp";
 
-// Mock loadSession to return null so we can test API-key-only auth paths
-mock.module("../morgen-cdp", () => ({
+// Mock loadSession to return null so we can test API-key-only auth paths.
+// Stubs the auth surface only; every other morgen-cdp export stays real, so this
+// registration cannot break other test files' static imports. See the helper.
+await mockMorgenCdp({
   loadSession: async () => null,
   saveSession: async () => {},
   isMorgenRunning: async () => false,
   authenticate: async () => ({ email: "", expiresAt: 0, source: "electron" }),
   refreshSession: async () => { throw new Error("no stored session"); },
   getSessionToken: async () => "",
-}));
+});
 
 describe("morgenFetch", () => {
   const originalEnv = process.env.MORGEN_API_KEY;

--- a/src/__tests__/morgen-cdp.test.ts
+++ b/src/__tests__/morgen-cdp.test.ts
@@ -27,8 +27,15 @@ mock.module("chrome-remote-interface", () => {
   return { default: cdpFn };
 });
 
-// Import the REAL morgen-cdp module via absolute path with cache-busting query
-// to avoid getting the stub mock set by other test files (chat.test.ts, morgen-api.test.ts).
+// Import morgen-cdp dynamically, AFTER the chrome-remote-interface mock above is
+// registered, so the module binds the mocked CDP client rather than the real one.
+// A static import would hoist above that mock.module call and bind the real CDP.
+// The cache-busting query forces a fresh evaluation even if another test file
+// already loaded morgen-cdp against the real chrome-remote-interface.
+//
+// NOTE: this is NOT about the old chat.test.ts / morgen-api.test.ts stub leak —
+// those now register complete mocks via helpers/mock-morgen-cdp.ts, so a plain
+// static import of morgen-cdp is safe elsewhere (see morgen-target.test.ts).
 const cdpModulePath = resolve(import.meta.dir, "../morgen-cdp.ts");
 const mod = await import(cdpModulePath + "?test-cdp");
 const isMorgenRunning = mod.isMorgenRunning as typeof import("../morgen-cdp").isMorgenRunning;

--- a/src/__tests__/morgen-target.test.ts
+++ b/src/__tests__/morgen-target.test.ts
@@ -1,18 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { resolve } from "path";
 import { hostMatches } from "../cdp-endpoint";
-
-// Import the REAL morgen-cdp module via absolute path with cache-busting query
-// to avoid getting the stub mock set by other test files (chat.test.ts,
-// morgen-api.test.ts), which call mock.module("../morgen-cdp", ...) globally.
-// Same pattern as morgen-cdp.test.ts; see comment there for rationale.
-const cdpModulePath = resolve(import.meta.dir, "../morgen-cdp.ts");
-const mod = await import(cdpModulePath + "?test-target");
-const classifyTarget = mod.classifyTarget as typeof import("../morgen-cdp").classifyTarget;
-const pickTarget = mod.pickTarget as typeof import("../morgen-cdp").pickTarget;
-const rankTargets = mod.rankTargets as typeof import("../morgen-cdp").rankTargets;
-const noTargetHint = mod.noTargetHint as typeof import("../morgen-cdp").noTargetHint;
-const withTimeout = mod.withTimeout as typeof import("../morgen-cdp").withTimeout;
+import { classifyTarget, pickTarget, rankTargets, noTargetHint, withTimeout } from "../morgen-cdp";
 
 describe("rankTargets", () => {
   const page = (url: string) => ({ type: "page", url });


### PR DESCRIPTION
bun's `mock.module` is process-global and permanent for the run. `chat.test.ts` and `morgen-api.test.ts` each registered a **hand-written stub** for `../morgen-cdp` omitting `classifyTarget`/`pickTarget`/`rankTargets`/`noTargetHint`/`withTimeout`, so any file importing those statically died — but **only when bun happened to load a mocking file first**.

That order differs by platform: the suite was **161/0 on Linux, 106/3 on macOS**. Every green Linux run was luck. The previous fix dodged it for one file with a cache-busting import; this removes the class.

## `mock.restore()` cannot do it

Probed directly in bun 1.3.14: it restores **spies only** and does **not** un-register module mocks. A stub with `afterAll(() => mock.restore())` still leaked into the next file:

```
SyntaxError: Export named 'beta' not found in module '/tmp/mprobe/real.ts'
```

So the obvious fix was unusable and the shape had to change.

## The fix

`helpers/mock-morgen-cdp.ts` loads the **real** module (cache-busted, so genuine regardless of load order) and spreads it under the caller's overrides. The stub's export surface is never hand-written, so **it cannot be incomplete** — and it's typed `Partial<typeof import(...)>`, so a nonexistent export can't be stubbed either.

**`morgen-target.test.ts` deliberately keeps its plain static import.** That is the proof the hazard is gone rather than routed around — it is the exact import that used to fail.

`mock-isolation.test.ts` guards the pattern by scanning test sources for a raw `mock.module` of morgen-cdp. It reads text, not module state, so it fails identically on every platform.

## Honest limit

A leaked stub still overrides the six auth functions it intends to stub, so a future test asserting real `loadSession` behaviour via static import would see a stub. That is a **wrong-value** failure, not a crash. The **missing-export crash class** is what is now impossible. Documented in the guard rather than glossed.

## Also: test hygiene

Adds `bunfig.toml` + `helpers/preload.ts` pointing `MORGEN_SESSION_FILE` at a fresh temp dir before any test file evaluates. `cli.test.ts` and `tasks.test.ts` already hand-rolled this defence ("in case the parent suite set it"); `tools.test.ts` did not. Centralising it means the suite cannot read the developer's real `~/.config/morgen-cli/session.json`.

## Verification

| check | result |
|---|---|
| hazard order A (chat first, **static import**) | 48 / 0 |
| hazard order B (morgen-api first, **static import**) | 35 / 0 |
| every file alone | 12/12, 0 fail |
| 5 randomized full-suite orders | 163 / 0, all five |
| full suite | **163 / 0** (161 + 2 guards) |
| `tsc --noEmit` | 75 = main |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZvrft29zMGgks5abHVtVK